### PR TITLE
use standard github token

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,14 +33,14 @@ jobs:
         with:
           repository: ${{ github.repository_owner }}/rpg-api
           path: rpg-api
-          token: ${{ secrets.GH_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Checkout rpg-dnd5e-web
         uses: actions/checkout@v4
         with:
           repository: ${{ github.repository_owner }}/rpg-dnd5e-web
           path: rpg-dnd5e-web
-          token: ${{ secrets.GH_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -61,7 +61,7 @@ jobs:
           tags: |
             type=ref,event=branch
             type=ref,event=pr
-            type=sha,prefix={{branch}}-
+            type=sha
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Extract metadata for Web
@@ -72,7 +72,7 @@ jobs:
           tags: |
             type=ref,event=branch
             type=ref,event=pr
-            type=sha,prefix={{branch}}-
+            type=sha
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push API image

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     container_name: rpg-redis-dev
     restart: unless-stopped
     ports:
-      - "6379:6379"  # Expose for local development
+      - "6380:6379"  # Expose on 6380 for local development (6379 is in use)
     volumes:
       - redis_dev_data:/data
     networks:
@@ -40,6 +40,20 @@ services:
       timeout: 10s
       retries: 3
 
+  envoy:
+    image: envoyproxy/envoy:v1.31-latest
+    container_name: rpg-envoy
+    restart: unless-stopped
+    expose:
+      - "8080"
+    volumes:
+      - ./envoy/envoy.yaml:/etc/envoy/envoy.yaml:ro
+    depends_on:
+      - rpg-api
+    networks:
+      - rpg-network
+    command: /usr/local/bin/envoy -c /etc/envoy/envoy.yaml -l info
+
   rpg-web:
     build:
       context: ../rpg-dnd5e-web
@@ -66,6 +80,7 @@ services:
     depends_on:
       - rpg-api
       - rpg-web
+      - envoy
     networks:
       - rpg-network
 

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -60,7 +60,7 @@ http {
 
         # SPA fallback for client-side routing
         location @fallback {
-            proxy_pass http://rpg_web/index.html;
+            proxy_pass http://rpg_web;
         }
 
         # Health check endpoint


### PR DESCRIPTION
This pull request includes updates to configuration files to improve security, address port conflicts, and enhance the system's architecture by introducing a new service. Below are the most important changes grouped by theme:

### Security Improvements:
* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L36-R43): Replaced `secrets.GH_TOKEN` with `secrets.GITHUB_TOKEN` for better integration with GitHub Actions' recommended practices.

### Port Configuration:
* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L9-R9): Changed the Redis service's exposed port from `6379` to `6380` to resolve a local port conflict.

### Architectural Enhancements:
* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R43-R56): Added a new `envoy` service using the Envoy proxy to improve request routing and observability. This includes configuration for the image, container, volumes, and dependencies.
* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R83): Updated the `depends_on` section of the `rpg-web` service to include the new `envoy` service, ensuring proper startup order.

### Routing Fix:
* [`nginx/nginx.conf`](diffhunk://#diff-4adaaefa7fc959e7dfe65e8dc8dadc9ee27ddd284eee3426463b1cdc000587d5L63-R63): Updated the fallback route in the Nginx configuration to proxy requests directly to `http://rpg_web` instead of appending `/index.html`.