### PR TITLE
Fix CloudFormation COMPOSE_VERSION variable error

### DIFF
--- a/aws/cloudformation/rpg-infrastructure.yaml
+++ b/aws/cloudformation/rpg-infrastructure.yaml
@@ -235,7 +235,7 @@ Resources:
           echo "=== Installing Docker Compose plugin ==="
           mkdir -p /usr/local/lib/docker/cli-plugins
           COMPOSE_VERSION="v2.24.1"
-          curl -SL "https://github.com/docker/compose/releases/download/${COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/lib/docker/cli-plugins/docker-compose
+          curl -SL "https://github.com/docker/compose/releases/download/$COMPOSE_VERSION/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/lib/docker/cli-plugins/docker-compose
           if [ $? -ne 0 ]; then
             echo "ERROR: Failed to download Docker Compose"
             /opt/aws/bin/cfn-signal -e 1 --stack ${AWS::StackName} --resource RPGServer --region ${AWS::Region}


### PR DESCRIPTION
## Summary
Fix CloudFormation validation error by removing curly braces from bash variable.

## Problem
CloudFormation was interpreting `${COMPOSE_VERSION}` as a template parameter reference, causing:
```
ValidationError: Template format error: Unresolved resource dependencies [COMPOSE_VERSION]
```

## Solution
Changed `${COMPOSE_VERSION}` to `$COMPOSE_VERSION` in the bash script.

## Test plan
- [ ] Merge PR to trigger deployment
- [ ] Verify CloudFormation template validates successfully
- [ ] Confirm EC2 instance provisions correctly

🤖 Generated with [Claude Code](https://claude.ai/code)