### PR TITLE
Add ec2:StopInstances permission

### DIFF
--- a/aws/rpg-deployment-policy.json
+++ b/aws/rpg-deployment-policy.json
@@ -27,6 +27,8 @@
         "ec2:CreateTags",
         "ec2:RunInstances",
         "ec2:TerminateInstances",
+        "ec2:StopInstances",
+        "ec2:StartInstances",
         "ec2:CreateSecurityGroup",
         "ec2:AuthorizeSecurityGroupIngress",
         "ec2:AuthorizeSecurityGroupEgress",


### PR DESCRIPTION
## Summary
Add missing `ec2:StopInstances` and `ec2:StartInstances` permissions to fix CloudFormation update failures.

## Problem
CloudFormation failed with:
```
User: arn:aws:iam::383277354112:user/rpg-deployment-github is not authorized to perform: ec2:StopInstances
```

## Solution
Added `ec2:StopInstances` and `ec2:StartInstances` to the IAM policy.

## Test plan
- [ ] Update IAM policy in AWS Console
- [ ] Retry deployment

🤖 Generated with [Claude Code](https://claude.ai/code)