### PR TITLE
Switch to pre-built Docker images for faster deployment

### DIFF
--- a/aws/cloudformation/rpg-infrastructure.yaml
+++ b/aws/cloudformation/rpg-infrastructure.yaml
@@ -254,46 +254,23 @@ Resources:
           mkdir -p /opt/rpg-deployment
           chown ubuntu:ubuntu /opt/rpg-deployment
           
-          # Create directory structure and clone repositories
-          echo "=== Creating directory structure ==="
-          cd /opt
-          mkdir -p rpg-apps
-          chown ubuntu:ubuntu rpg-apps
-          cd rpg-apps
-          
-          echo "=== Cloning repositories ==="
+          # Clone deployment repository only (using pre-built images)
+          echo "=== Cloning rpg-deployment repository ==="
           START_TIME=$(date +%s)
-          
-          echo "Cloning rpg-deployment..."
-          sudo -u ubuntu git clone https://github.com/KirkDiggler/rpg-deployment.git
+          cd /opt/rpg-deployment
+          sudo -u ubuntu git clone https://github.com/KirkDiggler/rpg-deployment.git .
           if [ $? -ne 0 ]; then
             echo "ERROR: Failed to clone rpg-deployment repository"
             /opt/aws/bin/cfn-signal -e 1 --stack ${AWS::StackName} --resource RPGServer --region ${AWS::Region}
             exit 1
           fi
           
-          echo "Cloning rpg-api..."
-          sudo -u ubuntu git clone https://github.com/KirkDiggler/rpg-api.git
-          if [ $? -ne 0 ]; then
-            echo "ERROR: Failed to clone rpg-api repository"
-            /opt/aws/bin/cfn-signal -e 1 --stack ${AWS::StackName} --resource RPGServer --region ${AWS::Region}
-            exit 1
-          fi
-          
-          echo "Cloning rpg-dnd5e-web..."
-          sudo -u ubuntu git clone https://github.com/KirkDiggler/rpg-dnd5e-web.git
-          if [ $? -ne 0 ]; then
-            echo "ERROR: Failed to clone rpg-dnd5e-web repository"
-            /opt/aws/bin/cfn-signal -e 1 --stack ${AWS::StackName} --resource RPGServer --region ${AWS::Region}
-            exit 1
-          fi
-          
           END_TIME=$(date +%s)
-          echo "=== Repositories cloned in $((END_TIME - START_TIME)) seconds ==="
+          echo "=== Repository cloned in $((END_TIME - START_TIME)) seconds ==="
           
           # Start the application
           echo "=== Starting application with docker compose ==="
-          cd /opt/rpg-apps/rpg-deployment
+          cd /opt/rpg-deployment
           START_TIME=$(date +%s)
           sudo -u ubuntu docker compose up -d
           END_TIME=$(date +%s)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,9 +19,7 @@ services:
     command: redis-server --appendonly yes
 
   rpg-api:
-    build:
-      context: ../rpg-api
-      dockerfile: Dockerfile
+    image: ghcr.io/kirkdiggler/rpg-api:latest
     container_name: rpg-api
     restart: unless-stopped
     expose:
@@ -55,9 +53,7 @@ services:
     command: /usr/local/bin/envoy -c /etc/envoy/envoy.yaml -l info
 
   rpg-web:
-    build:
-      context: ../rpg-dnd5e-web
-      dockerfile: Dockerfile
+    image: ghcr.io/kirkdiggler/rpg-dnd5e-web:latest
     container_name: rpg-web
     restart: unless-stopped
     expose:


### PR DESCRIPTION
## Summary
Switch from building Docker images from source to using pre-built images from GitHub Container Registry.

## Changes
### docker-compose.yml
- Replace `build:` contexts with `image:` references
- Use `ghcr.io/kirkdiggler/rpg-api:latest`
- Use `ghcr.io/kirkdiggler/rpg-dnd5e-web:latest`

### CloudFormation user data script
- Remove cloning of rpg-api and rpg-dnd5e-web repositories
- Only clone rpg-deployment repository (contains docker-compose.yml)
- Simplified directory structure

## Benefits
- **Deployment time**: ~2 minutes instead of 20+ minutes
- **Reliability**: No build failures on EC2 instances
- **Consistency**: Same images used in CI and production
- **CloudFormation timeout**: No more 20-minute timeout issues

## Prerequisites
- ✅ rpg-api Docker workflow merged and image built
- ✅ rpg-dnd5e-web Docker workflow merged and image built
- ✅ Images available at GHCR

## Test plan
- [ ] Merge PR to trigger deployment
- [ ] Verify deployment completes in ~2 minutes
- [ ] Test application functionality
- [ ] Confirm all services are running

This should resolve the EC2 timeout issues we've been experiencing\!

🤖 Generated with [Claude Code](https://claude.ai/code)