### PR TITLE
Add workflow dispatch inputs and visibility for cross-repo triggers

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,14 +6,37 @@ on:
   pull_request:
     branches: [main]
   workflow_dispatch:
+    inputs:
+      source:
+        description: 'Source repository that triggered this deployment'
+        required: false
+        default: 'manual'
+        type: string
+      sha:
+        description: 'Commit SHA that triggered this deployment'
+        required: false
+        default: ''
+        type: string
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
     environment: production
 
     steps:
+      - name: Show deployment trigger info
+        run: |
+          echo "🚀 Starting deployment..."
+          echo "Triggered by: ${{ github.event_name }}"
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "Source: ${{ inputs.source }}"
+            echo "SHA: ${{ inputs.sha }}"
+          else
+            echo "Source: ${{ github.repository }}"
+            echo "SHA: ${{ github.sha }}"
+          fi
+
       - name: Checkout code
         uses: actions/checkout@v4
 
@@ -173,6 +196,17 @@ jobs:
           PUBLIC_IP="${{ steps.get-instance.outputs.public-ip }}"
           echo "## 🚀 Deployment Summary" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
+          
+          # Show what triggered this deployment
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "🎯 **Triggered by**: ${{ inputs.source }}" >> $GITHUB_STEP_SUMMARY
+            echo "📝 **Source SHA**: ${{ inputs.sha }}" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "🎯 **Triggered by**: Direct push to ${{ github.repository }}" >> $GITHUB_STEP_SUMMARY
+            echo "📝 **Source SHA**: ${{ github.sha }}" >> $GITHUB_STEP_SUMMARY
+          fi
+          echo "" >> $GITHUB_STEP_SUMMARY
+          
           if [ "${{ job.status }}" == "success" ]; then
             echo "✅ **Status**: Deployment successful!" >> $GITHUB_STEP_SUMMARY
             echo "🌐 **Application URL**: http://$PUBLIC_IP" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary

Enable automatic deployment triggers from rpg-api and rpg-dnd5e-web repositories by adding workflow_dispatch inputs and better visibility into what triggered each deployment.

## Changes

- Add workflow_dispatch inputs (source, sha) to deployment workflow
- Add logging to show what triggered each deployment  
- Update deployment summary to display trigger source and commit SHA
- Allow workflow_dispatch events in job condition

## Benefits

- Enables automatic deployment when rpg-api or rpg-dnd5e-web are updated
- Clear visibility into deployment triggers in GitHub Actions UI
- Better audit trail for deployments
- Supports both manual and automatic deployment workflows

## Testing

After merging:
1. rpg-api and rpg-dnd5e-web can trigger deployments automatically
2. Deployment summary will show "🎯 **Triggered by**: rpg-api" or "🎯 **Triggered by**: rpg-dnd5e-web"
3. Manual deployments still work and show "🎯 **Triggered by**: manual"

🤖 Generated with [Claude Code](https://claude.ai/code)