### PR TITLE
fix: use pipe delimiter in sed to properly replace DOMAIN_NAME variable

### DIFF
--- a/scripts/init-letsencrypt.sh
+++ b/scripts/init-letsencrypt.sh
@@ -48,7 +48,7 @@ echo "Starting certificate generation process..."
 cp /etc/nginx/nginx-initial.conf /etc/nginx/nginx.conf
 
 # Substitute domain name in nginx config
-sed -i "s/\${DOMAIN_NAME}/$DOMAIN_NAME/g" /etc/nginx/nginx.conf
+sed -i "s|\${DOMAIN_NAME}|$DOMAIN_NAME|g" /etc/nginx/nginx.conf
 
 # Start nginx with initial configuration
 nginx
@@ -80,7 +80,7 @@ echo "Certificate obtained successfully"
 cp /etc/nginx/nginx-ssl.conf /etc/nginx/nginx.conf
 
 # Substitute domain name in nginx config
-sed -i "s/\${DOMAIN_NAME}/$DOMAIN_NAME/g" /etc/nginx/nginx.conf
+sed -i "s|\${DOMAIN_NAME}|$DOMAIN_NAME|g" /etc/nginx/nginx.conf
 
 # Test nginx configuration
 nginx -t


### PR DESCRIPTION
- Change sed delimiter from / to | to avoid escaping issues
- This ensures ${DOMAIN_NAME} is properly replaced with the actual domain
- Fixes the 'unknown domain_name variable' nginx error