### PR TITLE
fix: add missing sed substitution when certificates already exist

### DIFF
--- a/scripts/init-letsencrypt.sh
+++ b/scripts/init-letsencrypt.sh
@@ -29,6 +29,9 @@ if [ -d "$CERT_PATH" ]; then
         # Use SSL configuration
         cp /etc/nginx/nginx-ssl.conf /etc/nginx/nginx.conf
         
+        # Substitute domain name in nginx config
+        sed -i "s|\${DOMAIN_NAME}|$DOMAIN_NAME|g" /etc/nginx/nginx.conf
+        
         # Test nginx configuration
         nginx -t
         


### PR DESCRIPTION
- When certificates already exist, the script was copying nginx-ssl.conf but not replacing ${DOMAIN_NAME} placeholders
- This caused nginx to interpret ${DOMAIN_NAME} as a variable reference
- Nginx then reported 'unknown domain_name variable' error
- Added the missing sed substitution to ensure domain is always replaced