### PR TITLE
fix: nginx configuration variable substitution and http2 deprecation

### DIFF
--- a/nginx/nginx-ssl.conf
+++ b/nginx/nginx-ssl.conf
@@ -33,7 +33,8 @@ http {
 
     # HTTPS server
     server {
-        listen 443 ssl http2;
+        listen 443 ssl;
+        http2 on;
         server_name ${DOMAIN_NAME};
 
         # SSL certificates

--- a/scripts/init-letsencrypt.sh
+++ b/scripts/init-letsencrypt.sh
@@ -30,7 +30,7 @@ if [ -d "$CERT_PATH" ]; then
         cp /etc/nginx/nginx-ssl.conf /etc/nginx/nginx.conf
         
         # Substitute domain name in nginx config
-        sed -i "s|\${DOMAIN_NAME}|$DOMAIN_NAME|g" /etc/nginx/nginx.conf
+        sed "s/\${DOMAIN_NAME}/${DOMAIN_NAME}/g" /etc/nginx/nginx-ssl.conf > /etc/nginx/nginx.conf
         
         # Test nginx configuration
         nginx -t


### PR DESCRIPTION
- Fixed sed command in init-letsencrypt.sh to properly replace ${DOMAIN_NAME} variables
- Updated nginx-ssl.conf to use new http2 directive syntax (http2 on) instead of deprecated listen directive
- Changed from cp + sed -i to direct sed output to avoid in-place editing issues

These fixes resolve the nginx restart loop caused by unknown domain_name variable error.