### PR TITLE
Fix/nginx startup sequence

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -126,7 +126,7 @@ jobs:
               "echo \"Stopping existing containers...\"",
               "docker compose -f docker-compose.prod.yml down",
               "echo \"Starting new containers...\"",
-              "docker compose -f docker-compose.prod.yml up -d",
+              "docker compose -f docker-compose.prod.yml up -d --build",
               "echo \"Waiting for services to start...\"",
               "sleep 15",
               "echo \"Checking container status:\"",


### PR DESCRIPTION
This pull request includes updates to the deployment workflow and the Let's Encrypt initialization script to improve the deployment process and streamline SSL certificate handling. The most important changes include adding a `--build` flag to the Docker Compose command, modifying how Nginx is managed during SSL setup, and improving substitution logic for domain names in Nginx configurations.

### Deployment Workflow Improvements:
* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L129-R129): Added the `--build` flag to the `docker compose up` command to ensure containers are rebuilt during deployment, preventing issues with stale images.

### Let's Encrypt Initialization Script Enhancements:
* [`scripts/init-letsencrypt.sh`](diffhunk://#diff-f887cfb4362a77537cb501c976b593ab2042030830995261c4b26e59f382a42dL38-R40): Removed redundant Nginx reload commands and clarified that Nginx will be started by the main entrypoint, simplifying the SSL setup process.
* [`scripts/init-letsencrypt.sh`](diffhunk://#diff-f887cfb4362a77537cb501c976b593ab2042030830995261c4b26e59f382a42dL54-R55): Updated the domain name substitution logic to use a pipe instead of in-place editing, ensuring compatibility and clarity when generating Nginx configurations. [[1]](diffhunk://#diff-f887cfb4362a77537cb501c976b593ab2042030830995261c4b26e59f382a42dL54-R55) [[2]](diffhunk://#diff-f887cfb4362a77537cb501c976b593ab2042030830995261c4b26e59f382a42dL83-R91)
* [`scripts/init-letsencrypt.sh`](diffhunk://#diff-f887cfb4362a77537cb501c976b593ab2042030830995261c4b26e59f382a42dL83-R91): Replaced the Nginx reload with a stop command after switching to the SSL configuration to ensure a clean transition, followed by a short wait to allow the process to terminate.