### PR TITLE
fix: add API base URL configuration for web app

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -61,6 +61,7 @@ services:
       - "80"
     environment:
       - VITE_DISCORD_CLIENT_ID=${VITE_DISCORD_CLIENT_ID}
+      - VITE_API_BASE_URL=/api
     depends_on:
       - rpg-api
       - envoy


### PR DESCRIPTION
Configure rpg-web to use /api endpoint instead of localhost:8080 This fixes the Content Security Policy violation in production