### PR TITLE
feat: add Discord OAuth token exchange service

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,10 @@ EMAIL=your-email@example.com
 
 # Discord Configuration (Required for Discord Activity)
 VITE_DISCORD_CLIENT_ID=your-discord-client-id
+DISCORD_CLIENT_ID=your-discord-client-id
+DISCORD_CLIENT_SECRET=your-discord-client-secret
+# Optional: Only needed if your Discord app has a specific redirect URI
+# DISCORD_REDIRECT_URI=https://your-domain.com/auth/callback
 
 # Optional: Override default service configurations
 # PORT=50051

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -53,6 +53,27 @@ services:
       - rpg-network
     command: /usr/local/bin/envoy -c /etc/envoy/envoy.yaml -l info
 
+  discord-auth:
+    build:
+      context: ./services/discord-auth
+      dockerfile: Dockerfile
+    container_name: rpg-discord-auth
+    restart: unless-stopped
+    expose:
+      - "8080"
+    environment:
+      - PORT=8080
+      - DISCORD_CLIENT_ID=${DISCORD_CLIENT_ID}
+      - DISCORD_CLIENT_SECRET=${DISCORD_CLIENT_SECRET}
+      - DISCORD_REDIRECT_URI=${DISCORD_REDIRECT_URI}
+    networks:
+      - rpg-network
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8080/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+
   rpg-web:
     image: ghcr.io/kirkdiggler/rpg-dnd5e-web:latest
     container_name: rpg-web
@@ -87,6 +108,7 @@ services:
       - rpg-api
       - rpg-web
       - envoy
+      - discord-auth
     networks:
       - rpg-network
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -104,6 +104,27 @@ services:
       timeout: 10s
       retries: 3
 
+  discord-auth:
+    build:
+      context: ./services/discord-auth
+      dockerfile: Dockerfile
+    container_name: rpg-discord-auth
+    restart: unless-stopped
+    expose:
+      - "8080"
+    environment:
+      - PORT=8080
+      - DISCORD_CLIENT_ID=${DISCORD_CLIENT_ID:-test_client_id}
+      - DISCORD_CLIENT_SECRET=${DISCORD_CLIENT_SECRET:-test_client_secret}
+      - DISCORD_REDIRECT_URI=${DISCORD_REDIRECT_URI}
+    networks:
+      - rpg-network
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8080/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+
   nginx:
     image: nginx:alpine
     container_name: rpg-nginx
@@ -118,6 +139,7 @@ services:
       - rpg-api
       - rpg-web
       - envoy
+      - discord-auth
     networks:
       - rpg-network
 

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -11,6 +11,10 @@ http {
         server rpg-web:80;
     }
 
+    upstream discord_auth {
+        server rpg-discord-auth:8080;
+    }
+
     # Rate limiting
     limit_req_zone $binary_remote_addr zone=api:10m rate=10r/s;
     limit_req_zone $binary_remote_addr zone=web:10m rate=30r/s;
@@ -24,6 +28,17 @@ http {
         add_header X-Frame-Options DENY;
         add_header X-Content-Type-Options nosniff;
         add_header X-XSS-Protection "1; mode=block";
+
+        # Discord auth routes
+        location /api/discord/ {
+            limit_req zone=api burst=10 nodelay;
+            
+            proxy_pass http://discord_auth;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
 
         # gRPC-Web API routes (via Envoy proxy)
         location /api/ {

--- a/services/discord-auth/.gitignore
+++ b/services/discord-auth/.gitignore
@@ -1,0 +1,22 @@
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool
+*.out
+
+# Go build output
+discord-auth
+
+# Dependency directories
+vendor/
+
+# Environment files
+.env
+.env.local

--- a/services/discord-auth/Dockerfile
+++ b/services/discord-auth/Dockerfile
@@ -1,0 +1,21 @@
+# Build stage
+FROM golang:1.21-alpine AS builder
+
+WORKDIR /app
+COPY go.mod ./
+RUN go mod download
+
+COPY main.go ./
+RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o discord-auth .
+
+# Final stage
+FROM alpine:latest
+
+RUN apk --no-cache add ca-certificates
+WORKDIR /root/
+
+COPY --from=builder /app/discord-auth .
+
+EXPOSE 8080
+
+CMD ["./discord-auth"]

--- a/services/discord-auth/README.md
+++ b/services/discord-auth/README.md
@@ -1,0 +1,79 @@
+# Discord Auth Service
+
+A lightweight HTTP service that handles Discord OAuth token exchange for the RPG Activity app.
+
+## Overview
+
+This service provides a single endpoint that exchanges Discord authorization codes for access tokens. It's designed to be used by frontend applications that need to authenticate with Discord but can't securely store client secrets.
+
+## API
+
+### POST /api/discord/token
+
+Exchanges a Discord authorization code for an access token.
+
+**Request Body:**
+```json
+{
+  "code": "string"
+}
+```
+
+**Response:**
+```json
+{
+  "access_token": "string"
+}
+```
+
+**Error Response:**
+```json
+{
+  "error": "string"
+}
+```
+
+### GET /health
+
+Health check endpoint that returns 200 OK.
+
+## Configuration
+
+The service requires the following environment variables:
+
+- `DISCORD_CLIENT_ID` - Your Discord application's client ID
+- `DISCORD_CLIENT_SECRET` - Your Discord application's client secret
+- `DISCORD_REDIRECT_URI` - (Optional) The redirect URI configured in Discord
+- `PORT` - (Optional) The port to listen on (default: 8080)
+
+## Development
+
+To run locally:
+
+```bash
+# Set environment variables
+export DISCORD_CLIENT_ID=your_client_id
+export DISCORD_CLIENT_SECRET=your_client_secret
+
+# Run the service
+go run main.go
+```
+
+## Docker
+
+Build the image:
+```bash
+docker build -t discord-auth .
+```
+
+Run the container:
+```bash
+docker run -p 8080:8080 \
+  -e DISCORD_CLIENT_ID=your_client_id \
+  -e DISCORD_CLIENT_SECRET=your_client_secret \
+  discord-auth
+```
+
+## Integration
+
+The service is integrated into the RPG deployment stack via docker-compose. Nginx routes `/api/discord/` requests to this service.

--- a/services/discord-auth/go.mod
+++ b/services/discord-auth/go.mod
@@ -1,0 +1,3 @@
+module github.com/KirkDiggler/rpg-deployment/services/discord-auth
+
+go 1.21

--- a/services/discord-auth/main.go
+++ b/services/discord-auth/main.go
@@ -1,0 +1,145 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"time"
+)
+
+type TokenRequest struct {
+	Code string `json:"code"`
+}
+
+type TokenResponse struct {
+	AccessToken string `json:"access_token"`
+}
+
+type DiscordTokenResponse struct {
+	AccessToken  string `json:"access_token"`
+	TokenType    string `json:"token_type"`
+	ExpiresIn    int    `json:"expires_in"`
+	RefreshToken string `json:"refresh_token"`
+	Scope        string `json:"scope"`
+}
+
+type ErrorResponse struct {
+	Error string `json:"error"`
+}
+
+func main() {
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+	}
+
+	http.HandleFunc("/api/discord/token", handleTokenExchange)
+	http.HandleFunc("/health", handleHealth)
+
+	log.Printf("Discord auth service starting on port %s", port)
+	if err := http.ListenAndServe(":"+port, nil); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func handleHealth(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte("OK"))
+}
+
+func handleTokenExchange(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req TokenRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		respondWithError(w, http.StatusBadRequest, "Invalid request body")
+		return
+	}
+
+	if req.Code == "" {
+		respondWithError(w, http.StatusBadRequest, "Code is required")
+		return
+	}
+
+	clientID := os.Getenv("DISCORD_CLIENT_ID")
+	clientSecret := os.Getenv("DISCORD_CLIENT_SECRET")
+	redirectURI := os.Getenv("DISCORD_REDIRECT_URI")
+
+	if clientID == "" || clientSecret == "" {
+		log.Printf("Missing required environment variables")
+		respondWithError(w, http.StatusInternalServerError, "Server configuration error")
+		return
+	}
+
+	// Exchange code for token with Discord
+	token, err := exchangeCodeForToken(req.Code, clientID, clientSecret, redirectURI)
+	if err != nil {
+		log.Printf("Failed to exchange code for token: %v", err)
+		respondWithError(w, http.StatusBadRequest, "Failed to exchange code")
+		return
+	}
+
+	respondWithJSON(w, http.StatusOK, TokenResponse{
+		AccessToken: token.AccessToken,
+	})
+}
+
+func exchangeCodeForToken(code, clientID, clientSecret, redirectURI string) (*DiscordTokenResponse, error) {
+	url := "https://discord.com/api/oauth2/token"
+
+	data := fmt.Sprintf("client_id=%s&client_secret=%s&grant_type=authorization_code&code=%s",
+		clientID, clientSecret, code)
+	if redirectURI != "" {
+		data += fmt.Sprintf("&redirect_uri=%s", redirectURI)
+	}
+
+	client := &http.Client{
+		Timeout: 10 * time.Second,
+	}
+
+	req, err := http.NewRequest("POST", url, bytes.NewBufferString(data))
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("discord returned status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var tokenResp DiscordTokenResponse
+	if err := json.Unmarshal(body, &tokenResp); err != nil {
+		return nil, err
+	}
+
+	return &tokenResp, nil
+}
+
+func respondWithError(w http.ResponseWriter, code int, message string) {
+	respondWithJSON(w, code, ErrorResponse{Error: message})
+}
+
+func respondWithJSON(w http.ResponseWriter, code int, payload interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	json.NewEncoder(w).Encode(payload)
+}

--- a/services/discord-auth/test.sh
+++ b/services/discord-auth/test.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Test script for Discord Auth Service
+
+echo "Testing Discord Auth Service..."
+
+# Test health endpoint
+echo -n "Health check: "
+curl -s http://localhost:8080/health
+echo
+
+# Test token endpoint with invalid code (expected to fail)
+echo "Testing token exchange with invalid code:"
+curl -X POST http://localhost:8080/api/discord/token \
+  -H "Content-Type: application/json" \
+  -d '{"code":"invalid_test_code"}' \
+  -s | jq .
+
+echo
+echo "Note: This should fail with Discord API error since we're using a fake code."
+echo "In production, the frontend will provide a real authorization code."

--- a/test-discord-auth.sh
+++ b/test-discord-auth.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+echo "🔍 Testing Discord Auth Integration"
+echo "=================================="
+
+# Check if services are running
+echo "1. Checking if services are up..."
+docker compose ps | grep -E "(discord-auth|nginx)" || echo "Services not running. Run: docker compose up -d"
+
+# Test health endpoint
+echo -e "\n2. Testing Discord Auth health endpoint..."
+curl -s http://localhost:8080/health && echo " ✅ Direct health check passed" || echo " ❌ Direct health check failed"
+
+# Test through nginx
+echo -e "\n3. Testing Discord Auth through nginx..."
+curl -s http://localhost/api/discord/token -X POST -H "Content-Type: application/json" -d '{"code":"test"}' | jq . || echo "Failed to reach auth service through nginx"
+
+echo -e "\n4. Checking nginx logs for routing..."
+docker logs rpg-nginx 2>&1 | tail -5
+
+echo -e "\n✨ Test complete!"
+echo "Note: The token exchange will fail with a test code - that's expected."
+echo "The important thing is that the request reaches the service."


### PR DESCRIPTION
- Create lightweight Go service for secure token exchange
- Add POST /api/discord/token endpoint
- Configure nginx routing for /api/discord/*
- Add service to docker-compose for dev and prod
- Include health check endpoint
- Add required Discord env vars to .env.example

Implements #28