### PR TITLE
fix: add Discord OAuth secrets to deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -119,6 +119,8 @@ jobs:
               "echo \"DOMAIN_NAME=${{ secrets.DOMAIN_NAME }}\" > .env",
               "echo \"EMAIL=${{ secrets.SSL_EMAIL }}\" >> .env",
               "echo \"VITE_DISCORD_CLIENT_ID=${{ secrets.VITE_DISCORD_CLIENT_ID }}\" >> .env",
+              "echo \"DISCORD_CLIENT_ID=${{ secrets.VITE_DISCORD_CLIENT_ID }}\" >> .env",
+              "echo \"DISCORD_CLIENT_SECRET=${{ secrets.DISCORD_CLIENT_SECRET }}\" >> .env",
               "echo \"Logging into GitHub Container Registry...\"",
               "echo \"${{ secrets.GITHUB_TOKEN }}\" | docker login ghcr.io -u ${{ github.actor }} --password-stdin",
               "echo \"Pulling latest pre-built images...\"",

--- a/README.md
+++ b/README.md
@@ -27,11 +27,24 @@ Complete deployment pipeline for the RPG gaming platform with modular architectu
 
 Set these secrets in your GitHub repository settings:
 
+**AWS Secrets:**
 ```bash
 AWS_ACCESS_KEY_ID=your-aws-access-key
 AWS_SECRET_ACCESS_KEY=your-aws-secret-key
 AWS_KEY_PAIR_NAME=your-ec2-key-pair-name
+```
+
+**Discord OAuth Secrets:**
+```bash
+VITE_DISCORD_CLIENT_ID=your-discord-client-id   # Used for both frontend and backend
+DISCORD_CLIENT_SECRET=your-discord-client-secret # From Discord Developer Portal (OAuth2 section)
+```
+
+**Optional:**
+```bash
 GH_TOKEN=github-token-for-private-repos  # If using private repos
+DOMAIN_NAME=your-domain.com              # For SSL certificates
+SSL_EMAIL=your-email@example.com         # For Let's Encrypt
 ```
 
 ### 2. Deploy via GitHub Actions

--- a/debug-discord-auth.sh
+++ b/debug-discord-auth.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+echo "🔍 Discord Auth Service Debug Script"
+echo "===================================="
+
+# Check if all services are running
+echo -e "\n1. Checking service status..."
+docker ps --format "table {{.Names}}\t{{.Status}}" | grep -E "(discord-auth|nginx|envoy|rpg-web)" || echo "Some services not running"
+
+# Check Discord auth service logs
+echo -e "\n2. Discord auth service logs (last 20 lines):"
+docker logs rpg-discord-auth --tail 20 2>&1 || echo "Failed to get discord-auth logs"
+
+# Check nginx logs for routing issues
+echo -e "\n3. Nginx logs (last 10 lines):"
+docker logs rpg-nginx --tail 10 2>&1 || echo "Failed to get nginx logs"
+
+# Test health endpoint directly
+echo -e "\n4. Testing health endpoint directly:"
+docker exec rpg-discord-auth wget -qO- http://localhost:8080/health || echo "Health check failed"
+
+# Test through nginx
+echo -e "\n5. Testing through nginx (from inside container network):"
+docker exec rpg-nginx wget -qO- http://discord-auth:8080/health || echo "Failed to reach discord-auth from nginx"
+
+# Check environment variables
+echo -e "\n6. Checking Discord environment variables:"
+docker exec rpg-discord-auth printenv | grep DISCORD || echo "No Discord env vars found"
+
+# Test the actual endpoint
+echo -e "\n7. Testing token endpoint with curl:"
+docker exec rpg-nginx curl -s -X POST http://discord-auth:8080/api/discord/token \
+  -H "Content-Type: application/json" \
+  -d '{"code":"test"}' | jq . || echo "Failed to test token endpoint"
+
+# Check if nginx config has the right upstream
+echo -e "\n8. Checking nginx configuration:"
+docker exec rpg-nginx cat /etc/nginx/nginx.conf | grep -A5 "discord" || echo "No discord config found in nginx"
+
+# Network connectivity test
+echo -e "\n9. Testing network connectivity:"
+docker exec rpg-nginx ping -c 1 discord-auth || echo "Cannot ping discord-auth service"
+
+echo -e "\n✅ Debug complete!"


### PR DESCRIPTION
- Add DISCORD_CLIENT_ID and DISCORD_CLIENT_SECRET to .env generation
- Use VITE_DISCORD_CLIENT_ID for both frontend and backend (same value)
- Update README with required Discord secrets documentation

This fixes the 'failed to fetch' error by ensuring the auth service has the required credentials