### PR TITLE
Fix Discord auth CORS errors

### DIFF
--- a/test-discord-auth-cors.sh
+++ b/test-discord-auth-cors.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+echo "🧪 Testing Discord Auth Service CORS Headers"
+echo "==========================================="
+
+# Test health endpoint
+echo -e "\n1. Testing health endpoint:"
+curl -i -X GET http://localhost:8080/health
+
+# Test OPTIONS preflight request
+echo -e "\n\n2. Testing CORS preflight (OPTIONS):"
+curl -i -X OPTIONS http://localhost:8080/api/discord/token \
+  -H "Origin: http://localhost:5173" \
+  -H "Access-Control-Request-Method: POST" \
+  -H "Access-Control-Request-Headers: Content-Type"
+
+# Test POST request
+echo -e "\n\n3. Testing POST request with CORS:"
+curl -i -X POST http://localhost:8080/api/discord/token \
+  -H "Content-Type: application/json" \
+  -H "Origin: http://localhost:5173" \
+  -d '{"code":"test_code"}'
+
+echo -e "\n\n✅ Test complete!"


### PR DESCRIPTION
## Summary
- Fixes the "Failed to fetch" error in Discord activity authentication
- Adds proper CORS headers to the Discord auth service
- Resolves #31

## Changes
1. **Added CORS headers** to all endpoints:
   - `Access-Control-Allow-Origin: *`
   - Proper handling of OPTIONS preflight requests
   - Headers included in both success and error responses

2. **Enhanced logging** for better debugging:
   - Log incoming requests with method and remote address
   - Log environment variable status (masked for security)
   - Better error tracking

3. **Added test script** (`test-discord-auth-cors.sh`) to validate CORS configuration locally

## Test plan
- [x] Run `test-discord-auth-cors.sh` locally to verify CORS headers
- [ ] Deploy to production
- [ ] Test Discord authentication flow in browser
- [ ] Verify no CORS errors in browser console

🤖 Generated with [Claude Code](https://claude.ai/code)