### PR TITLE
Fix Discord auth SSL routing

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -121,6 +121,7 @@ jobs:
               "echo \"VITE_DISCORD_CLIENT_ID=${{ secrets.VITE_DISCORD_CLIENT_ID }}\" >> .env",
               "echo \"DISCORD_CLIENT_ID=${{ secrets.VITE_DISCORD_CLIENT_ID }}\" >> .env",
               "echo \"DISCORD_CLIENT_SECRET=${{ secrets.DISCORD_CLIENT_SECRET }}\" >> .env",
+              "echo \"DISCORD_REDIRECT_URI=https://${{ secrets.DOMAIN_NAME }}\" >> .env",
               "echo \"Logging into GitHub Container Registry...\"",
               "echo \"${{ secrets.GITHUB_TOKEN }}\" | docker login ghcr.io -u ${{ github.actor }} --password-stdin",
               "echo \"Pulling latest pre-built images...\"",

--- a/nginx/nginx-ssl.conf
+++ b/nginx/nginx-ssl.conf
@@ -11,6 +11,10 @@ http {
         server rpg-web:80;
     }
 
+    upstream discord_auth {
+        server rpg-discord-auth:8080;
+    }
+
     # Rate limiting
     limit_req_zone $binary_remote_addr zone=api:10m rate=10r/s;
     limit_req_zone $binary_remote_addr zone=web:10m rate=30r/s;
@@ -58,6 +62,20 @@ http {
         add_header X-Content-Type-Options nosniff;
         add_header X-XSS-Protection "1; mode=block";
         add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload";
+
+        # Discord auth routes
+        location /api/discord/ {
+            limit_req zone=api burst=10 nodelay;
+            
+            proxy_pass http://discord_auth;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            
+            # CORS headers handled by the service
+            add_header X-Frame-Options DENY always;
+        }
 
         # gRPC-Web API routes (via Envoy proxy)
         location /api/ {


### PR DESCRIPTION
## Summary
- Fixes Discord auth routing in production SSL configuration
- Adds missing environment variable for redirect URI
- Resolves #31

## Problem
The production nginx SSL configuration was missing the Discord auth routes, causing all `/api/discord/*` requests to return 301 redirects instead of being proxied to the Discord auth service.

## Changes
1. **Added `discord_auth` upstream** to nginx SSL config
2. **Added `/api/discord/` location block** to properly route requests
3. **Added `DISCORD_REDIRECT_URI`** environment variable in deployment

## Test Results
From the server logs, we saw:
- ✅ Discord auth container is running and healthy
- ❌ Requests to `/api/discord/token` were getting 301 redirects
- ❌ Missing `DISCORD_REDIRECT_URI` environment variable

This PR fixes all these issues.

## Deployment Steps
Once merged:
1. The GitHub Actions workflow will deploy automatically
2. Nginx will reload with the new configuration
3. Discord auth requests will be properly routed

🤖 Generated with [Claude Code](https://claude.ai/code)