### PR TITLE
Fix Discord proxy routing that strips /api prefix

### DIFF
--- a/debug-discord-auth.sh
+++ b/debug-discord-auth.sh
@@ -29,9 +29,13 @@ docker exec rpg-discord-auth printenv | grep DISCORD || echo "No Discord env var
 
 # Test the actual endpoint
 echo -e "\n7. Testing token endpoint with curl:"
-docker exec rpg-nginx curl -s -X POST http://discord-auth:8080/api/discord/token \
+response=$(docker exec rpg-nginx curl -s -w "\nHTTP_CODE:%{http_code}" -X POST http://discord-auth:8080/api/discord/token \
   -H "Content-Type: application/json" \
-  -d '{"code":"test"}' | jq . || echo "Failed to test token endpoint"
+  -d '{"code":"test"}')
+http_code=$(echo "$response" | grep "HTTP_CODE:" | cut -d: -f2)
+body=$(echo "$response" | sed '/HTTP_CODE:/d')
+echo "Response code: $http_code"
+echo "Response body: $body"
 
 # Check if nginx config has the right upstream
 echo -e "\n8. Checking nginx configuration:"

--- a/services/discord-auth/main.go
+++ b/services/discord-auth/main.go
@@ -44,10 +44,13 @@ func main() {
 		port = "8080"
 	}
 
+	// Handle both paths - Discord proxy strips /api prefix
 	http.HandleFunc("/api/discord/token", handleTokenExchange)
+	http.HandleFunc("/discord/token", handleTokenExchange)
 	http.HandleFunc("/health", handleHealth)
 
 	log.Printf("Discord auth service starting on port %s", port)
+	log.Printf("Handling token exchange at both /api/discord/token and /discord/token")
 	if err := http.ListenAndServe(":"+port, nil); err != nil {
 		log.Fatal(err)
 	}
@@ -65,7 +68,7 @@ func handleTokenExchange(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
 	w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
 	
-	log.Printf("Received %s request to /api/discord/token from %s", r.Method, r.RemoteAddr)
+	log.Printf("Received %s request to %s from %s", r.Method, r.URL.Path, r.RemoteAddr)
 	
 	// Handle preflight requests
 	if r.Method == http.MethodOptions {

--- a/test-discord-auth.sh
+++ b/test-discord-auth.sh
@@ -13,7 +13,22 @@ curl -s http://localhost:8080/health && echo " ✅ Direct health check passed" |
 
 # Test through nginx
 echo -e "\n3. Testing Discord Auth through nginx..."
-curl -s http://localhost/api/discord/token -X POST -H "Content-Type: application/json" -d '{"code":"test"}' | jq . || echo "Failed to reach auth service through nginx"
+response=$(curl -s -w "\nHTTP_CODE:%{http_code}" http://localhost/api/discord/token -X POST -H "Content-Type: application/json" -d '{"code":"test"}')
+http_code=$(echo "$response" | grep "HTTP_CODE:" | cut -d: -f2)
+body=$(echo "$response" | sed '/HTTP_CODE:/d')
+
+if [ "$http_code" = "301" ]; then
+    echo " ❌ Getting 301 redirect - nginx routing not configured properly"
+elif [ "$http_code" = "400" ] || [ "$http_code" = "500" ]; then
+    echo " ✅ Auth service reached (got $http_code - expected for test code)"
+    echo "Response: $body"
+elif [ "$http_code" = "200" ]; then
+    echo " ✅ Auth service reached successfully"
+    echo "Response: $body"
+else
+    echo " ❌ Unexpected response code: $http_code"
+    echo "Response: $body"
+fi
 
 echo -e "\n4. Checking nginx logs for routing..."
 docker logs rpg-nginx 2>&1 | tail -5


### PR DESCRIPTION
## Summary
- Discord Activities proxy strips the /api prefix when routing requests
- Added handler for /discord/token in addition to /api/discord/token
- Updated logging to show actual request path for debugging

## Problem
When using Discord's proxy (/.proxy/api/discord/token), the request arrives at our service as just /discord/token instead of /api/discord/token, causing a 405 Method Not Allowed error.

## Solution
The service now handles both paths to support:
- Direct API calls to /api/discord/token (normal usage)
- Discord proxy calls to /discord/token (Activity usage)

## Test plan
- [x] Code changes made
- [ ] Deploy to production
- [ ] Test Discord Activity authentication flow
- [ ] Verify logs show correct path being called