### PR TITLE
Fix nginx routing for Discord proxy paths

### DIFF
--- a/nginx/nginx-ssl.conf
+++ b/nginx/nginx-ssl.conf
@@ -77,6 +77,20 @@ http {
             add_header X-Frame-Options DENY always;
         }
 
+        # Discord proxy routes (Discord Activities strip /api prefix)
+        location /discord/ {
+            limit_req zone=api burst=10 nodelay;
+            
+            proxy_pass http://discord_auth;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            
+            # CORS headers handled by the service
+            add_header X-Frame-Options DENY always;
+        }
+
         # gRPC-Web API routes (via Envoy proxy)
         location /api/ {
             limit_req zone=api burst=20 nodelay;


### PR DESCRIPTION
## Summary
- Added nginx location block for /discord/ paths
- Discord Activities proxy strips the /api prefix when forwarding requests
- Now nginx can route both /api/discord/ and /discord/ to the auth service

## Problem
Nginx was returning 405 Method Not Allowed for /discord/token because it had no location block to handle paths without the /api prefix.

## Solution
Added a location block for /discord/ that proxies to the Discord auth service, matching the existing /api/discord/ configuration.

## Test plan
- [x] Code changes made
- [ ] Deploy to production
- [ ] Test Discord Activity authentication flow
- [ ] Verify requests reach the Discord auth service