### PR TITLE
Fix Discord proxy gRPC-Web routing

### DIFF
--- a/DISCORD_AUTH_HANDOFF.md
+++ b/DISCORD_AUTH_HANDOFF.md
@@ -1,0 +1,48 @@
+# Discord Authentication Handoff Summary
+
+## What We Accomplished Today
+
+### Fixed the "Failed to fetch" Error ✅
+Started with a Discord Activity that showed "Failed to fetch" when clicking authorize. Through systematic debugging, we:
+
+1. **Added CORS headers** to the Discord auth service
+2. **Fixed nginx routing** to include Discord auth endpoints
+3. **Discovered Discord's proxy behavior** - it strips `/api` prefix from paths
+4. **Updated services to handle both paths**:
+   - `/api/discord/token` (normal web usage)
+   - `/discord/token` (Discord Activity proxy usage)
+
+### Current State
+- **Authentication works!** 🎉
+- Participants list loads
+- No more fetch errors
+- Just need to update UI to show authenticated user
+
+### Key Learnings
+1. Discord Activities use a proxy pattern: `/.proxy/api/discord/token`
+2. The proxy strips the `/api` prefix, so requests arrive as `/discord/token`
+3. Need to handle both routing patterns in nginx and backend services
+4. Discord proxy mapping configuration: set to `/api` in Discord app settings
+
+### Debugging Commands Used
+```bash
+# Check service logs
+docker logs rpg-discord-auth --tail 50
+
+# Check nginx logs  
+docker logs rpg-nginx --tail 30
+
+# View nginx config
+docker exec rpg-nginx cat /etc/nginx/nginx-ssl.conf
+
+# Check environment variables
+docker exec rpg-discord-auth env | grep DISCORD
+```
+
+### Final Issue
+Issue #36: UI doesn't update after successful authentication
+- Auth succeeds but user state not populated
+- See TODO comment in DiscordProvider.tsx line 117
+
+## Next Session
+Just need to update the DiscordProvider to properly set user state after authentication!

--- a/nginx/nginx-ssl.conf
+++ b/nginx/nginx-ssl.conf
@@ -91,6 +91,34 @@ http {
             add_header X-Frame-Options DENY always;
         }
 
+        # gRPC-Web routes when Discord proxy strips /api prefix
+        # Matches patterns like: dnd5e.api.v1alpha1.CharacterService/ListCharacters
+        location ~ ^/[a-zA-Z0-9]+\.[a-zA-Z0-9]+\.[a-zA-Z0-9]+\.[a-zA-Z0-9]+Service/ {
+            limit_req zone=api burst=20 nodelay;
+            
+            proxy_pass http://rpg_envoy;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            
+            # Required for gRPC-Web
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+            
+            # Only allow from Discord origins
+            set $allow_request 0;
+            if ($http_referer ~ discordsays\.com) {
+                set $allow_request 1;
+            }
+            if ($allow_request = 0) {
+                return 404;
+            }
+            
+            add_header X-Frame-Options DENY always;
+        }
+
         # gRPC-Web API routes (via Envoy proxy)
         location /api/ {
             limit_req zone=api burst=20 nodelay;


### PR DESCRIPTION
## Summary
- Added nginx location block to handle gRPC-Web requests when Discord proxy strips /api prefix
- Restricted access to Discord referrers only for security
- Fixes 405 errors for gRPC-Web calls in Discord Activities

## Problem
When running as a Discord Activity, Discord's proxy strips the `/api` prefix from requests. This causes gRPC-Web requests like `/dnd5e.api.v1alpha1.CharacterService/ListCharacters` to bypass the nginx `/api/` location block and fall through to the React app, resulting in 405 (Method Not Allowed) errors.

## Solution
Added a new location block that:
1. Matches gRPC service patterns (e.g., `service.name.version.ServiceName/Method`)
2. Routes these requests to the Envoy proxy
3. Only allows requests with Discord referrers (discordsays.com)
4. Includes all necessary gRPC-Web headers

This follows the same pattern as the Discord auth fix where both `/api/discord/` and `/discord/` paths are handled.

## Test plan
- [ ] Deploy to staging
- [ ] Test gRPC-Web requests work in Discord Activity mode
- [ ] Verify requests from non-Discord sources are blocked (404)
- [ ] Confirm normal web app functionality still works

Fixes KirkDiggler/rpg-dnd5e-web#36

🤖 Generated with [Claude Code](https://claude.ai/code)