### PR TITLE
Fix Redis environment variable for rpg-api

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -28,7 +28,7 @@ services:
       - PORT=50051
       - LOG_LEVEL=info
       - ENV=production
-      - REDIS_URL=redis://redis:6379
+      - REDIS_ADDR=redis:6379
     depends_on:
       - redis
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
     environment:
       - PORT=50051
       - LOG_LEVEL=info
-      - REDIS_URL=redis://redis:6379
+      - REDIS_ADDR=redis:6379
       - DND5E_API_URL=http://dnd-api:3000/api/2014/
     depends_on:
       - redis


### PR DESCRIPTION
## Summary
- Fixed environment variable mismatch causing Redis connection failures
- Changed `REDIS_URL` to `REDIS_ADDR` to match what rpg-api expects

## Problem
The rpg-api service was failing with "failed to list characters" errors because it couldn't connect to Redis. Investigation revealed that:
- rpg-api code expects `REDIS_ADDR` environment variable
- Docker compose was providing `REDIS_URL=redis://redis:6379`
- This caused rpg-api to fall back to `localhost:6379` and fail to connect

## Solution
Updated both `docker-compose.yml` and `docker-compose.prod.yml` to use `REDIS_ADDR=redis:6379` instead of `REDIS_URL`.

## Test plan
- [ ] Deploy the updated docker-compose configuration
- [ ] Verify rpg-api can connect to Redis container
- [ ] Test that ListCharacters API works in Discord Activity
- [ ] Check logs to confirm no more "failed to list characters" errors

This fix works together with the nginx routing fix in PR #37 to fully resolve the Discord Activity API issues.

🤖 Generated with [Claude Code](https://claude.ai/code)