### PR TITLE
fix: Remove force-renewal flag to prevent Let's Encrypt rate limits

### DIFF
--- a/scripts/init-letsencrypt.sh
+++ b/scripts/init-letsencrypt.sh
@@ -60,14 +60,13 @@ sleep 5
 
 echo "Requesting certificate from Let's Encrypt..."
 
-# Request certificate
+# Request certificate (without force-renewal to avoid rate limits)
 certbot certonly \
     --webroot \
     --webroot-path=/var/www/certbot \
     --email "$EMAIL" \
     --agree-tos \
     --no-eff-email \
-    --force-renewal \
     -d "$DOMAIN_NAME"
 
 # Check if certificate was obtained successfully


### PR DESCRIPTION
## Summary
- Removed `--force-renewal` flag from certbot command in init-letsencrypt.sh
- This prevents requesting new certificates on every container restart
- Fixes the "too many certificates" rate limit error

## Problem
The nginx container was requesting a new Let's Encrypt certificate every time it started due to the `--force-renewal` flag. This quickly exhausted the rate limit of 5 certificates per week for the same domain.

## Solution
Removed the `--force-renewal` flag so certbot will:
- Only request a new certificate if one doesn't exist
- Use the existing valid certificate from the persistent volume
- Let the renewal cron job handle certificate renewals (only when < 30 days to expiration)

## Test plan
- [x] Verify the init script still checks for existing certificates
- [x] Confirm volumes are properly mounted for persistence
- [x] Ensure renewal script uses proper `certbot renew` command

🤖 Generated with [Claude Code](https://claude.ai/code)