### PR TITLE
feat: Add Cloudflare support and HTTP-only mode

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -104,6 +104,7 @@ services:
     environment:
       - DOMAIN_NAME=${DOMAIN_NAME}
       - EMAIL=${EMAIL}
+      - SSL_MODE=${SSL_MODE:-ssl}
     depends_on:
       - rpg-api
       - rpg-web

--- a/docs/cloudflare-setup.md
+++ b/docs/cloudflare-setup.md
@@ -1,0 +1,72 @@
+# Cloudflare Setup Guide
+
+This guide explains how to use rpg-deployment with Cloudflare for SSL/TLS.
+
+## Why Use Cloudflare?
+
+- **Instant SSL**: No Let's Encrypt rate limits
+- **DDoS Protection**: Free protection against attacks
+- **Global CDN**: Faster loading times worldwide
+- **Hide Server IP**: Additional security layer
+
+## Setup Instructions
+
+### 1. Configure Cloudflare
+
+1. Sign up at [cloudflare.com](https://cloudflare.com)
+2. Add your domain
+3. Update nameservers at your registrar
+4. In Cloudflare dashboard:
+   - Go to **SSL/TLS** → **Overview**
+   - Set encryption mode to **"Flexible"** (temporarily)
+
+### 2. Deploy with HTTP Mode
+
+```bash
+# Set environment variable
+export SSL_MODE=http
+
+# Deploy
+docker-compose -f docker-compose.prod.yml up -d
+```
+
+### 3. After Getting Let's Encrypt Certificates
+
+Once you have valid certificates (no rate limits):
+
+1. Remove the SSL_MODE variable:
+   ```bash
+   unset SSL_MODE
+   ```
+
+2. Redeploy:
+   ```bash
+   docker-compose -f docker-compose.prod.yml up -d nginx
+   ```
+
+3. In Cloudflare, change SSL mode to **"Full"** for end-to-end encryption
+
+## Environment Variables
+
+- `SSL_MODE=http` - Use HTTP-only mode (for Cloudflare Flexible SSL)
+- `SSL_MODE=ssl` (default) - Use HTTPS with Let's Encrypt
+
+## Features
+
+The HTTP mode configuration includes:
+- Cloudflare IP detection for accurate visitor IPs
+- Proper security headers
+- Rate limiting
+- Health check endpoints
+- ACME challenge support (for future certificate generation)
+
+## Troubleshooting
+
+### Rate Limited by Let's Encrypt
+The system automatically falls back to HTTP mode if rate limited.
+
+### Real Visitor IPs
+The configuration automatically detects and logs real visitor IPs when behind Cloudflare.
+
+### CORS Issues
+The HTTP configuration includes proper CORS headers for gRPC-Web support.

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -9,6 +9,7 @@ RUN mkdir -p /var/www/certbot
 # Copy nginx configurations
 COPY nginx/nginx-initial.conf /etc/nginx/nginx-initial.conf
 COPY nginx/nginx-ssl.conf /etc/nginx/nginx-ssl.conf
+COPY nginx/nginx-http.conf /etc/nginx/nginx-http.conf
 
 # Copy scripts
 COPY scripts/init-letsencrypt.sh /usr/local/bin/init-letsencrypt.sh

--- a/nginx/nginx-http.conf
+++ b/nginx/nginx-http.conf
@@ -1,0 +1,147 @@
+events {
+    worker_connections 1024;
+}
+
+http {
+    include /etc/nginx/mime.types;
+    default_type application/octet-stream;
+
+    # Cloudflare IP ranges for real IP detection
+    set_real_ip_from 173.245.48.0/20;
+    set_real_ip_from 103.21.244.0/22;
+    set_real_ip_from 103.22.200.0/22;
+    set_real_ip_from 103.31.4.0/22;
+    set_real_ip_from 141.101.64.0/18;
+    set_real_ip_from 108.162.192.0/18;
+    set_real_ip_from 190.93.240.0/20;
+    set_real_ip_from 188.114.96.0/20;
+    set_real_ip_from 197.234.240.0/22;
+    set_real_ip_from 198.41.128.0/17;
+    set_real_ip_from 162.158.0.0/15;
+    set_real_ip_from 104.16.0.0/13;
+    set_real_ip_from 104.24.0.0/14;
+    set_real_ip_from 172.64.0.0/13;
+    set_real_ip_from 131.0.72.0/22;
+    set_real_ip_from 2400:cb00::/32;
+    set_real_ip_from 2606:4700::/32;
+    set_real_ip_from 2803:f800::/32;
+    set_real_ip_from 2405:b500::/32;
+    set_real_ip_from 2405:8100::/32;
+    set_real_ip_from 2a06:98c0::/29;
+    set_real_ip_from 2c0f:f248::/32;
+    
+    # Use the CF-Connecting-IP header for the real IP
+    real_ip_header CF-Connecting-IP;
+
+    # Logging
+    access_log /var/log/nginx/access.log;
+    error_log /var/log/nginx/error.log;
+
+    # Gzip compression
+    gzip on;
+    gzip_vary on;
+    gzip_proxied any;
+    gzip_comp_level 6;
+    gzip_types text/plain text/css text/xml text/javascript application/json application/javascript application/xml+rss application/rss+xml application/atom+xml image/svg+xml;
+
+    # Rate limiting zones
+    limit_req_zone $binary_remote_addr zone=api_limit:10m rate=30r/s;
+    limit_req_zone $binary_remote_addr zone=web_limit:10m rate=60r/s;
+
+    # Upstream definitions
+    upstream rpg_api {
+        server envoy:8080;
+        keepalive 32;
+    }
+
+    upstream rpg_web {
+        server rpg-web:80;
+        keepalive 32;
+    }
+
+    upstream discord_auth {
+        server discord-auth:8080;
+        keepalive 32;
+    }
+
+    server {
+        listen 80;
+        server_name ${DOMAIN_NAME};
+        
+        # Security headers (less strict for HTTP behind Cloudflare)
+        add_header X-Frame-Options "SAMEORIGIN" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-XSS-Protection "1; mode=block" always;
+        add_header Referrer-Policy "no-referrer-when-downgrade" always;
+
+        # ACME challenge location for Let's Encrypt (for future use)
+        location /.well-known/acme-challenge/ {
+            root /var/www/certbot;
+        }
+
+        # Health check endpoint
+        location /health {
+            access_log off;
+            return 200 "healthy\n";
+            add_header Content-Type text/plain;
+        }
+
+        # Discord OAuth endpoints
+        location /auth/discord {
+            proxy_pass http://discord_auth;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto https;
+            proxy_set_header X-Forwarded-Host $host;
+            proxy_read_timeout 300s;
+            proxy_connect_timeout 75s;
+        }
+
+        # API proxy
+        location /api/ {
+            limit_req zone=api_limit burst=50 nodelay;
+            
+            proxy_pass http://rpg_api/;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto https;
+            proxy_set_header X-Forwarded-Host $host;
+            
+            # gRPC-Web specific headers
+            proxy_set_header Connection "";
+            proxy_buffering off;
+            
+            # CORS headers for gRPC-Web
+            add_header 'Access-Control-Allow-Origin' '*' always;
+            add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS' always;
+            add_header 'Access-Control-Allow-Headers' 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Content-Transfer-Encoding,Custom-Header-1,X-Accept-Content-Transfer-Encoding,X-Accept-Response-Streaming,X-User-Agent,X-Grpc-Web,Grpc-Timeout' always;
+            add_header 'Access-Control-Expose-Headers' 'Content-Transfer-Encoding,Grpc-Message,Grpc-Status' always;
+            
+            if ($request_method = 'OPTIONS') {
+                return 204;
+            }
+        }
+
+        # Main web app
+        location / {
+            limit_req zone=web_limit burst=100 nodelay;
+            
+            proxy_pass http://rpg_web;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto https;
+            proxy_set_header X-Forwarded-Host $host;
+            proxy_set_header Connection "";
+            
+            # Discord Activity specific headers
+            add_header 'X-Frame-Options' '' always;
+            add_header 'Content-Security-Policy' "frame-ancestors https://discord.com https://discordapp.com https://discord.com.de https://canary.discord.com https://ptb.discord.com https://cdn.discordapp.com;" always;
+        }
+    }
+}

--- a/scripts/init-letsencrypt.sh
+++ b/scripts/init-letsencrypt.sh
@@ -46,6 +46,26 @@ fi
 
 echo "Starting certificate generation process..."
 
+# Check if we should use HTTP-only mode (e.g., behind Cloudflare)
+if [ "$SSL_MODE" = "http" ]; then
+    echo "SSL_MODE set to 'http' - configuring HTTP-only mode"
+    sed "s/\${DOMAIN_NAME}/${DOMAIN_NAME}/g" /etc/nginx/nginx-http.conf > /etc/nginx/nginx.conf
+    nginx -t
+    echo "Nginx configured for HTTP-only mode (Cloudflare compatible)"
+    exit 0
+fi
+
+# Check if we're rate limited by looking for recent failed attempts
+if [ -f /var/log/letsencrypt/letsencrypt.log ]; then
+    if grep -q "too many certificates already issued" /var/log/letsencrypt/letsencrypt.log 2>/dev/null; then
+        echo "WARNING: Rate limited by Let's Encrypt. Using HTTP-only configuration."
+        sed "s/\${DOMAIN_NAME}/${DOMAIN_NAME}/g" /etc/nginx/nginx-http.conf > /etc/nginx/nginx.conf
+        nginx -t
+        echo "Nginx configured for HTTP-only mode due to rate limits"
+        exit 0
+    fi
+fi
+
 # Use initial configuration for certificate generation
 cp /etc/nginx/nginx-initial.conf /etc/nginx/nginx.conf
 
@@ -72,6 +92,18 @@ certbot certonly \
 # Check if certificate was obtained successfully
 if [ ! -f "$CERT_PATH/fullchain.pem" ]; then
     echo "Error: Certificate generation failed"
+    
+    # Check if it's a rate limit error
+    if grep -q "too many certificates already issued" /var/log/letsencrypt/letsencrypt.log 2>/dev/null; then
+        echo "Rate limited by Let's Encrypt. Falling back to HTTP-only mode."
+        nginx -s stop
+        sleep 2
+        sed "s/\${DOMAIN_NAME}/${DOMAIN_NAME}/g" /etc/nginx/nginx-http.conf > /etc/nginx/nginx.conf
+        nginx -t
+        echo "Nginx configured for HTTP-only mode"
+        exit 0
+    fi
+    
     exit 1
 fi
 


### PR DESCRIPTION
## Summary
- Added support for running behind Cloudflare with HTTP-only mode
- Added automatic fallback when Let's Encrypt rate-limited
- Added proper Cloudflare IP detection and headers

## Problem
When hitting Let's Encrypt rate limits (5 certificates per week), the service becomes unavailable. This PR adds support for running behind Cloudflare as an alternative SSL solution.

## Solution
1. **New nginx-http.conf**: Full-featured HTTP configuration with Cloudflare IP detection
2. **SSL_MODE environment variable**: Control SSL behavior (http/ssl)
3. **Automatic fallback**: Detects rate limits and switches to HTTP mode
4. **Cloudflare compatibility**: Proper headers and real IP detection

## Usage

### Behind Cloudflare (Flexible SSL):
```bash
export SSL_MODE=http
docker-compose -f docker-compose.prod.yml up -d
```

### Direct SSL (Let's Encrypt):
```bash
# Default behavior, no SSL_MODE needed
docker-compose -f docker-compose.prod.yml up -d
```

## Features
- Cloudflare IP ranges for accurate visitor tracking
- Security headers adapted for HTTP mode
- Rate limiting preserved
- CORS headers for gRPC-Web
- Discord Activity CSP headers

## Test plan
- [x] Test HTTP mode configuration syntax
- [x] Verify SSL_MODE environment variable handling
- [x] Test automatic fallback on rate limit detection
- [ ] Deploy and test with Cloudflare Flexible SSL
- [ ] Verify real IP detection works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)