### PR TITLE
fix: Add Discord Activity location blocks to HTTP config

### DIFF
--- a/nginx/nginx-http.conf
+++ b/nginx/nginx-http.conf
@@ -99,6 +99,48 @@ http {
             proxy_connect_timeout 75s;
         }
 
+        # Discord proxy routes (Discord Activities strip /api prefix)
+        location /discord/ {
+            limit_req zone=api_limit burst=10 nodelay;
+            
+            proxy_pass http://discord_auth;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto https;
+            
+            # CORS headers handled by the service
+            add_header X-Frame-Options DENY always;
+        }
+
+        # gRPC-Web routes when Discord proxy strips /api prefix
+        # Matches patterns like: dnd5e.api.v1alpha1.CharacterService/ListCharacters
+        location ~ ^/[a-zA-Z0-9]+\.[a-zA-Z0-9]+\.[a-zA-Z0-9]+\.[a-zA-Z0-9]+Service/ {
+            limit_req zone=api_limit burst=20 nodelay;
+            
+            proxy_pass http://rpg_api;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto https;
+            
+            # Required for gRPC-Web
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+            
+            # Only allow from Discord origins
+            set $allow_request 0;
+            if ($http_referer ~ discordsays\.com) {
+                set $allow_request 1;
+            }
+            if ($allow_request = 0) {
+                return 404;
+            }
+            
+            add_header X-Frame-Options DENY always;
+        }
+
         # API proxy
         location /api/ {
             limit_req zone=api_limit burst=50 nodelay;


### PR DESCRIPTION
- Added /discord/ location for Discord Activity proxy routes
- Added gRPC-Web pattern matching for Discord stripped paths
- Added referer check for discordsays.com origins

These were present in SSL config but missing from HTTP config, causing 405 errors for Discord Activity authentication.

🤖 Generated with [Claude Code](https://claude.ai/code)