### PR TITLE
fix: Add SSL_MODE=http to deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -122,6 +122,7 @@ jobs:
               "echo \"DISCORD_CLIENT_ID=${{ secrets.VITE_DISCORD_CLIENT_ID }}\" >> .env",
               "echo \"DISCORD_CLIENT_SECRET=${{ secrets.DISCORD_CLIENT_SECRET }}\" >> .env",
               "echo \"DISCORD_REDIRECT_URI=https://${{ secrets.DOMAIN_NAME }}\" >> .env",
+              "echo \"SSL_MODE=http\" >> .env",
               "echo \"Logging into GitHub Container Registry...\"",
               "echo \"${{ secrets.GITHUB_TOKEN }}\" | docker login ghcr.io -u ${{ github.actor }} --password-stdin",
               "echo \"Cleaning up existing deployment...\"",


### PR DESCRIPTION
The deployment workflow was overwriting .env file without preserving SSL_MODE=http, causing nginx to attempt certificate generation instead of using HTTP mode behind Cloudflare.

🤖 Generated with [Claude Code](https://claude.ai/code)