### PR TITLE
feat: Separate auth endpoints from API routes

### DIFF
--- a/nginx/nginx-ssl.conf
+++ b/nginx/nginx-ssl.conf
@@ -64,7 +64,7 @@ http {
         add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload";
 
         # Discord auth routes
-        location /api/discord/ {
+        location /auth/ {
             limit_req zone=api burst=10 nodelay;
             
             proxy_pass http://discord_auth;

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -30,7 +30,7 @@ http {
         add_header X-XSS-Protection "1; mode=block";
 
         # Discord auth routes
-        location /api/discord/ {
+        location /auth/ {
             limit_req zone=api burst=10 nodelay;
             
             proxy_pass http://discord_auth;

--- a/services/discord-auth/main.go
+++ b/services/discord-auth/main.go
@@ -44,13 +44,13 @@ func main() {
 		port = "8080"
 	}
 
-	// Handle both paths - Discord proxy strips /api prefix
-	http.HandleFunc("/api/discord/token", handleTokenExchange)
-	http.HandleFunc("/discord/token", handleTokenExchange)
+	// Handle auth paths - nginx proxies /auth/ to this service
+	http.HandleFunc("/auth/discord/token", handleTokenExchange)
+	http.HandleFunc("/discord/token", handleTokenExchange)  // Keep for backward compatibility
 	http.HandleFunc("/health", handleHealth)
 
 	log.Printf("Discord auth service starting on port %s", port)
-	log.Printf("Handling token exchange at both /api/discord/token and /discord/token")
+	log.Printf("Handling token exchange at /auth/discord/token and /discord/token")
 	if err := http.ListenAndServe(":"+port, nil); err != nil {
 		log.Fatal(err)
 	}

--- a/test-discord-auth.sh
+++ b/test-discord-auth.sh
@@ -13,7 +13,7 @@ curl -s http://localhost:8080/health && echo " ✅ Direct health check passed" |
 
 # Test through nginx
 echo -e "\n3. Testing Discord Auth through nginx..."
-response=$(curl -s -w "\nHTTP_CODE:%{http_code}" http://localhost/api/discord/token -X POST -H "Content-Type: application/json" -d '{"code":"test"}')
+response=$(curl -s -w "\nHTTP_CODE:%{http_code}" http://localhost/auth/discord/token -X POST -H "Content-Type: application/json" -d '{"code":"test"}')
 http_code=$(echo "$response" | grep "HTTP_CODE:" | cut -d: -f2)
 body=$(echo "$response" | sed '/HTTP_CODE:/d')
 


### PR DESCRIPTION
## Summary
Separates authentication endpoints from API routes to prevent routing conflicts with gRPC service paths.

## Problem
- Discord proxy had prefix mapping for `/api` which conflicted with gRPC service paths like `/api.v1alpha1.DiceService`
- This caused 405 Method Not Allowed errors when calling the dice service through Discord
- The `/api` prefix was ambiguous between REST auth endpoints and gRPC service names

## Solution
- Move Discord auth from `/api/discord/` to `/auth/`
- Update nginx routing to send `/auth/` to discord-auth service
- Update discord-auth service to handle new paths
- Clear separation between auth and API routes

## Changes
- **nginx.conf**: Route `/auth/` to discord-auth service instead of `/api/discord/`
- **nginx-ssl.conf**: Same routing update for SSL configuration
- **discord-auth/main.go**: Handle `/auth/discord/token` (keeps backward compatibility)
- **test-discord-auth.sh**: Update test script to use new endpoint

## Testing
- Run `./test-discord-auth.sh` to verify auth endpoint works
- Rebuild discord-auth service: `docker-compose build discord-auth`
- Test with rpg-dnd5e-web client (requires companion PR)

## Related
- Companion PR needed in rpg-dnd5e-web to update client
- Fixes 405 errors when calling dice service through Discord Activity

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>