### PR TITLE
fix: Remove obsolete /api/ location blocks causing 405 errors

### DIFF
--- a/nginx/nginx-http.conf
+++ b/nginx/nginx-http.conf
@@ -141,32 +141,7 @@ http {
             add_header X-Frame-Options DENY always;
         }
 
-        # API proxy
-        location /api/ {
-            limit_req zone=api_limit burst=50 nodelay;
-            
-            proxy_pass http://rpg_api/;
-            proxy_http_version 1.1;
-            proxy_set_header Host $host;
-            proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header X-Forwarded-Proto https;
-            proxy_set_header X-Forwarded-Host $host;
-            
-            # gRPC-Web specific headers
-            proxy_set_header Connection "";
-            proxy_buffering off;
-            
-            # CORS headers for gRPC-Web
-            add_header 'Access-Control-Allow-Origin' '*' always;
-            add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS' always;
-            add_header 'Access-Control-Allow-Headers' 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Content-Transfer-Encoding,Custom-Header-1,X-Accept-Content-Transfer-Encoding,X-Accept-Response-Streaming,X-User-Agent,X-Grpc-Web,Grpc-Timeout' always;
-            add_header 'Access-Control-Expose-Headers' 'Content-Transfer-Encoding,Grpc-Message,Grpc-Status' always;
-            
-            if ($request_method = 'OPTIONS') {
-                return 204;
-            }
-        }
+        # gRPC-Web routes are handled by the regex location above
 
         # Main web app
         location / {

--- a/nginx/nginx-ssl.conf
+++ b/nginx/nginx-ssl.conf
@@ -119,27 +119,7 @@ http {
             add_header X-Frame-Options DENY always;
         }
 
-        # gRPC-Web API routes (via Envoy proxy)
-        location /api/ {
-            limit_req zone=api burst=20 nodelay;
-            
-            # Remove /api prefix and forward to Envoy proxy
-            rewrite ^/api/(.*)$ /$1 break;
-            
-            proxy_pass http://rpg_envoy;
-            proxy_set_header Host $host;
-            proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header X-Forwarded-Proto $scheme;
-            
-            # Required for gRPC-Web
-            proxy_http_version 1.1;
-            proxy_set_header Upgrade $http_upgrade;
-            proxy_set_header Connection "upgrade";
-            
-            # Restrictive headers for API routes
-            add_header X-Frame-Options DENY always;
-        }
+        # gRPC-Web routes are handled by the regex location above
 
         # React app (default route)
         location / {

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -40,24 +40,7 @@ http {
             proxy_set_header X-Forwarded-Proto $scheme;
         }
 
-        # gRPC-Web API routes (via Envoy proxy)
-        location /api/ {
-            limit_req zone=api burst=20 nodelay;
-            
-            # Remove /api prefix and forward to Envoy proxy
-            rewrite ^/api/(.*)$ /$1 break;
-            
-            proxy_pass http://rpg_envoy;
-            proxy_set_header Host $host;
-            proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header X-Forwarded-Proto $scheme;
-            
-            # Required for gRPC-Web
-            proxy_http_version 1.1;
-            proxy_set_header Upgrade $http_upgrade;
-            proxy_set_header Connection "upgrade";
-        }
+        # gRPC-Web routes are handled by Envoy directly via root location
 
         # React app (default route)
         location / {
@@ -97,9 +80,6 @@ http {
     #     ssl_ciphers ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384;
 
     #     # Same location blocks as above
-    #     location /api/ {
-    #         # ... (same as HTTP version)
-    #     }
 
     #     location / {
     #         # ... (same as HTTP version)


### PR DESCRIPTION
## Summary
Removes obsolete `/api/` location blocks from all nginx configurations that were causing 405 errors for gRPC service calls.

## Problem
- The `/api/` location block was matching paths like `/api.v1alpha1.DiceService/RollDice`
- nginx would strip `/api/` leaving `.v1alpha1.DiceService/RollDice` - an invalid path
- This resulted in 405 Method Not Allowed errors for dice service calls through Discord Activity

## Root Cause
- nginx matches `/api.v1alpha1` with the `/api/` location because the path starts with `/api/`
- The auth endpoints were already moved from `/api/discord` to `/auth/` in previous PR
- The `/api/` location block was no longer needed but wasn't removed

## Solution
- Remove `/api/` location blocks from all nginx configs
- gRPC service paths are properly handled by the existing regex location that matches service patterns
- This allows `/api.v1alpha1.DiceService/*` to be correctly forwarded to Envoy

## Testing
After deployment:
```bash
# Should return a gRPC response (not 405)
curl -X POST https://rpg-toolkit.app/api.v1alpha1.DiceService/RollDice \
  -H "Content-Type: application/json" \
  -d '{"entity_id":"test","context":"test","notation":"1d20"}'
```

## Impact
- Fixes dice service calls through Discord Activity
- No impact on other services (character service already working)
- No impact on auth (already using /auth/ endpoint)

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>