### PR TITLE
fix: update nginx configs to properly route gRPC services

### DIFF
--- a/nginx/nginx-http.conf
+++ b/nginx/nginx-http.conf
@@ -115,7 +115,7 @@ http {
 
         # gRPC-Web routes when Discord proxy strips /api prefix
         # Matches patterns like: dnd5e.api.v1alpha1.CharacterService/ListCharacters
-        location ~ ^/[a-zA-Z0-9]+\.[a-zA-Z0-9]+\.[a-zA-Z0-9]+\.[a-zA-Z0-9]+Service/ {
+        location ~ ^/[a-zA-Z0-9]+(\.[a-zA-Z0-9]+)+Service/ {
             limit_req zone=api_limit burst=20 nodelay;
             
             proxy_pass http://rpg_api;

--- a/nginx/nginx-ssl.conf
+++ b/nginx/nginx-ssl.conf
@@ -93,7 +93,7 @@ http {
 
         # gRPC-Web routes when Discord proxy strips /api prefix
         # Matches patterns like: dnd5e.api.v1alpha1.CharacterService/ListCharacters
-        location ~ ^/[a-zA-Z0-9]+\.[a-zA-Z0-9]+\.[a-zA-Z0-9]+\.[a-zA-Z0-9]+Service/ {
+        location ~ ^/[a-zA-Z0-9]+(\.[a-zA-Z0-9]+)+Service/ {
             limit_req zone=api burst=20 nodelay;
             
             proxy_pass http://rpg_envoy;

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -40,7 +40,21 @@ http {
             proxy_set_header X-Forwarded-Proto $scheme;
         }
 
-        # gRPC-Web routes are handled by Envoy directly via root location
+        # gRPC-Web service routes
+        location ~ ^/[a-zA-Z0-9]+(\.[a-zA-Z0-9]+)+Service/ {
+            limit_req zone=api burst=20 nodelay;
+            
+            proxy_pass http://rpg_envoy;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            
+            # Required for gRPC-Web
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+        }
 
         # React app (default route)
         location / {


### PR DESCRIPTION
## Summary
- Add gRPC service location block to nginx.conf  
- Fix regex pattern in all configs to match variable segment counts (2+)
- Pattern now matches both 3-segment (api.v1alpha1.DiceService) and 4-segment services

## Problem
The dice service was returning HTTP 405 errors through Discord proxy because:
1. The nginx /api/ location block was incorrectly matching gRPC service paths like /api.v1alpha1.DiceService
2. The regex pattern expected exactly 4 segments but dice service only has 3

## Solution  
- Added proper gRPC service routing location blocks
- Updated regex from fixed 4-segment to flexible 2+ segment pattern: `^/[a-zA-Z0-9]+(\.[a-zA-Z0-9]+)+Service/`
- This ensures all gRPC service paths are properly routed regardless of namespace depth

## Test Plan
- [x] Verify dice service calls work through Discord proxy
- [x] Verify character service calls still work  
- [x] Confirm no routing conflicts with /auth endpoints

Resolves the HTTP 405 errors for dice service calls through Discord Activity.