### PR TITLE
fix(nginx): stop buffering/truncating gRPC-Web server streams

### DIFF
--- a/nginx/nginx-ssl.conf
+++ b/nginx/nginx-ssl.conf
@@ -19,6 +19,14 @@ http {
     limit_req_zone $binary_remote_addr zone=api:10m rate=10r/s;
     limit_req_zone $binary_remote_addr zone=web:10m rate=30r/s;
 
+    # Only send "Connection: upgrade" when the client actually requests an
+    # upgrade; a bare "Connection: upgrade" with no Upgrade header corrupts
+    # plain streaming requests (grpc-web server streams).
+    map $http_upgrade $connection_upgrade {
+        default upgrade;
+        ''      "";
+    }
+
     # HTTP server - redirects to HTTPS except for ACME challenges
     server {
         listen 80;
@@ -105,7 +113,16 @@ http {
             # Required for gRPC-Web
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
-            proxy_set_header Connection "upgrade";
+            proxy_set_header Connection $connection_upgrade;
+
+            # gRPC-Web server streaming: never buffer or re-chunk stream
+            # frames (buffered envelopes abort connect-es with "incomplete
+            # envelope"), and keep long-lived streams open past the 60s
+            # default read timeout. rpg-dnd5e-web#495.
+            proxy_buffering off;
+            proxy_cache off;
+            proxy_read_timeout 3600s;
+            proxy_send_timeout 3600s;
             
             # Only allow from Discord origins
             set $allow_request 0;


### PR DESCRIPTION
## What

Three changes to the gRPC-Web `Service` location in `nginx/nginx-ssl.conf`:

1. `proxy_buffering off` + `proxy_cache off` — nginx's default buffering re-chunks grpc-web server-stream frames; connect-es reads a cut envelope and aborts the stream with `protocol error: incomplete envelope` (Kirk's live Discord console capture).
2. `proxy_read_timeout`/`proxy_send_timeout` 3600s — the 60s default kills long-lived encounter streams mid-envelope.
3. Conditional `Connection` header via the standard `map $http_upgrade` pattern — previously a bare `Connection: upgrade` was sent with no `Upgrade` header on every plain streaming request.

## Why

The deployed half of rpg-dnd5e-web#495: in the real Discord path (Discord /.proxy → nginx → envoy) the encounter stream died right after `SnapshotDelivered`, so clients rendered the snapshot (walls/entities/HP) but never received the replay `GeometryRevealed` — one-tile floor, no click targets, no movement. Local/dev is envoy-direct and never saw it. Three client-side investigations falsified every code theory before the console capture pinned the transport.

## Verification

- `nginx -t` parse-validated in a container (with upstream/cert hosts stubbed — failures beyond parse are host-environment artifacts).
- Real verification is post-deploy: reload the Discord activity → the revealed floor should span the full sight radius on connect, and click-to-move should work. That retest closes rpg-dnd5e-web#495.

## Scope decisions

- Only `nginx-ssl.conf` (the production config) is touched; the local/dev configs don't sit in front of Discord streaming and can be aligned later if desired.
- Rate-limit (`limit_req`) on the stream route left as-is — streams are one request, not bursts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013gA28TEYiq8UFMqbTZL3K9