### PR TITLE
fix(nginx): port grpc-web streaming fix to nginx-http.conf (the config prod actually runs)

### DIFF
--- a/nginx/nginx-http.conf
+++ b/nginx/nginx-http.conf
@@ -48,6 +48,15 @@ http {
     limit_req_zone $binary_remote_addr zone=api_limit:10m rate=30r/s;
     limit_req_zone $binary_remote_addr zone=web_limit:10m rate=60r/s;
 
+    # Only send "Connection: upgrade" when the client actually requests an
+    # upgrade; a bare "Connection: upgrade" with no Upgrade header corrupts
+    # plain streaming requests (grpc-web server streams). Keep in sync with
+    # nginx-ssl.conf's map block — see #52.
+    map $http_upgrade $connection_upgrade {
+        default upgrade;
+        ''      "";
+    }
+
     # Upstream definitions
     upstream rpg_api {
         server envoy:8080;
@@ -115,20 +124,34 @@ http {
 
         # gRPC-Web routes when Discord proxy strips /api prefix
         # Matches patterns like: dnd5e.api.v1alpha1.CharacterService/ListCharacters
+        #
+        # Prod runs http mode behind Cloudflare (SSL_MODE=http in deploy.yml,
+        # Cloudflare terminates TLS) — THIS is the Service block that's actually
+        # live, not nginx-ssl.conf's. Keep both blocks in sync. See #52 / #51 /
+        # rpg-dnd5e-web#495.
         location ~ ^/[a-zA-Z0-9]+(\.[a-zA-Z0-9]+)+Service/ {
             limit_req zone=api_limit burst=20 nodelay;
-            
+
             proxy_pass http://rpg_api;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto https;
-            
+
             # Required for gRPC-Web
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
-            proxy_set_header Connection "upgrade";
-            
+            proxy_set_header Connection $connection_upgrade;
+
+            # gRPC-Web server streaming: never buffer or re-chunk stream
+            # frames (buffered envelopes abort connect-es with "incomplete
+            # envelope"), and keep long-lived streams open past the 60s
+            # default read timeout. rpg-dnd5e-web#495.
+            proxy_buffering off;
+            proxy_cache off;
+            proxy_read_timeout 3600s;
+            proxy_send_timeout 3600s;
+
             # Only allow from Discord origins
             set $allow_request 0;
             if ($http_referer ~ discordsays\.com) {

--- a/nginx/nginx-ssl.conf
+++ b/nginx/nginx-ssl.conf
@@ -101,6 +101,10 @@ http {
 
         # gRPC-Web routes when Discord proxy strips /api prefix
         # Matches patterns like: dnd5e.api.v1alpha1.CharacterService/ListCharacters
+        #
+        # Prod actually runs nginx-http.conf (SSL_MODE=http behind Cloudflare) —
+        # this block is not the one in the live request path. Keep both in
+        # sync. See #52.
         location ~ ^/[a-zA-Z0-9]+(\.[a-zA-Z0-9]+)+Service/ {
             limit_req zone=api burst=20 nodelay;
             


### PR DESCRIPTION
## What

Ports #51's gRPC-Web streaming fix to `nginx/nginx-http.conf`'s Service location — the same four changes #51 made to `nginx-ssl.conf`:

1. Conditional `Connection` header via the standard `map $http_upgrade $connection_upgrade` pattern (was a bare `Connection: upgrade` sent on every request, even non-upgrade ones).
2. `proxy_buffering off` + `proxy_cache off`.
3. `proxy_read_timeout` / `proxy_send_timeout` raised to `3600s` (was the 60s default).
4. Cross-reference comments in both files' Service location blocks pointing at each other, so this can't silently drift out of sync again.

## Why this file and not just `nginx-ssl.conf`

#51 assumed `nginx-ssl.conf` was the production config. It isn't. `rpg-deployment/.github/workflows/deploy.yml` writes `SSL_MODE=http` into prod's `.env` on every deploy, and `scripts/init-letsencrypt.sh` selects `nginx-http.conf` whenever `SSL_MODE=http` is set. Prod runs behind Cloudflare in Flexible-SSL mode (Cloudflare terminates TLS at the edge; origin nginx never sees HTTPS) — confirmed live: `https://rpg-toolkit.app/health` returns a Cloudflare-issued (Google Trust Services) edge cert, not Let's Encrypt, and plain `http://rpg-toolkit.app/health` returns `200` with no redirect, which only happens if the origin's port-80 server is `nginx-http.conf`'s (serves `/health` directly) rather than `nginx-ssl.conf`'s (unconditionally 301s to https). So #51's fix landed in a file that was never in the live request path — this PR is the fix that's actually deployed-relevant.

## Verification

- `nginx -t` parse-validated in a container for both files (upstream hosts stubbed via `--add-host`, `nginx-ssl.conf` also needs a throwaway self-signed cert stubbed at the Let's Encrypt path — same technique #51 used).
- **A/B evidence — real repro, not simulated**: stood up `ghcr.io/kirkdiggler/rpg-api:latest` + real `envoy` + a devseeded free-roam encounter behind each literal file (this PR's `nginx-http.conf` vs. `origin/main`'s), opened `StreamEncounter`, and let it sit idle (no moves) past 60s:
  - **Before** (`origin/main`'s `nginx-http.conf`, unpatched): stream delivered the snapshot, then died at `EXIT_TIME=60.002192` (`HTTP 200`, clean close — not an error, nginx's default `proxy_read_timeout`).
  - **After** (this branch's `nginx-http.conf`, patched): same setup, same devseed fixture, stream survived the full 75s test window (`EXIT_TIME=75.003600`, `HTTP 200` — client-side `--max-time` cutoff, not a server kill).

This reproduces the deployed half of rpg-dnd5e-web#495 end-to-end locally and confirms the fix. Full investigation trail (including the config-mismatch discovery and the separate rate-limit/503-HTML finding) is on rpg-dnd5e-web#495.

## Scope decisions

- Full dedupe of both files' Service location into a shared `include` snippet was considered but deferred — the two files differ enough elsewhere (SSL vs Cloudflare-flexible headers, upstream naming) that a clean include felt like a separate, riskier change. Cross-reference comments are the interim guardrail; tracked as a follow-up if it recurs.
- rpg-deployment#53 (rate-limit burst returns nginx's raw HTML 503 page, which a grpc-web client misparses as a corrupt envelope) is a separate, already-filed issue — not in scope here.
- rpg-dnd5e-web#507 (client silently reconnects on clean stream close with no console.error) is also separate and already filed — not in scope here.

Closes #52. Refs rpg-dnd5e-web#495, #51.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
