### PR TITLE
Add authorization to envoy CORS allow_headers

### DIFF
--- a/envoy/envoy.yaml
+++ b/envoy/envoy.yaml
@@ -41,7 +41,7 @@ static_resources:
                         allow_origin_string_match:
                           - prefix: "*"
                         allow_methods: GET, PUT, DELETE, POST, OPTIONS
-                        allow_headers: keep-alive,user-agent,cache-control,content-type,content-transfer-encoding,custom-header-1,x-accept-content-transfer-encoding,x-accept-response-streaming,x-user-agent,x-grpc-web,grpc-timeout,connect-protocol-version,connect-timeout-ms,connect-accept-encoding,connect-content-encoding
+                        allow_headers: keep-alive,user-agent,cache-control,content-type,content-transfer-encoding,custom-header-1,x-accept-content-transfer-encoding,x-accept-response-streaming,x-user-agent,x-grpc-web,grpc-timeout,connect-protocol-version,connect-timeout-ms,connect-accept-encoding,connect-content-encoding,authorization
                         max_age: "1728000"
                         expose_headers: grpc-status,grpc-message
                 http_filters:


### PR DESCRIPTION
## Summary

- `envoy/envoy.yaml`'s CORS `allow_headers` list is missing `authorization`.
- ConnectRPC sends the `Authorization` header for dev-auth; envoy's CORS preflight response must allow it, or browser clients are blocked from calling through envoy in the local-dev stack.
- Found during asset-pipeline browser verification, and hit independently by two separate sessions who each had to hand-patch this locally.

## Change

Added `authorization` to the single CORS `allow_headers` list in `envoy/envoy.yaml` (only one CORS block exists in this repo — no other envoy configs needed the same fix).

## Test plan

- [x] Confirmed only one CORS block exists in `envoy/envoy.yaml` (and no other envoy config files in the repo)
- [x] `python3 -c "import yaml,sys; yaml.safe_load(open('envoy/envoy.yaml'))"` — parses cleanly
- [x] `docker run --rm -v $(pwd)/envoy/envoy.yaml:/etc/envoy/envoy.yaml:ro envoyproxy/envoy:v1.31-latest --mode validate -c /etc/envoy/envoy.yaml` (same image tag pinned in `docker-compose.yml`) — `configuration OK`, no new warnings/errors introduced

— asset-pipeline agent, on behalf of KirkDiggler