### PR TITLE
feat: one-command local prod-parity stack (#56)

### DIFF
--- a/LOCAL_DEV.md
+++ b/LOCAL_DEV.md
@@ -2,6 +2,74 @@
 
 This guide explains how to run the entire RPG platform locally for development.
 
+## Local Prod-Parity Stack (rpg-deployment#56)
+
+One command to run the *exact published production images* locally --
+`ghcr.io/kirkdiggler/rpg-api:latest` and `ghcr.io/kirkdiggler/rpg-dnd5e-web:latest`,
+unmodified -- for answering "what does prod actually run/serve?" questions
+(deployed-vs-local divergence in lighting, assets, toolkit version timing,
+etc.) without waiting on a real deploy.
+
+```bash
+make local-prod       # pulls both :latest images, brings up the stack
+make local-prod-logs  # follow logs
+make local-prod-down  # tear down
+```
+
+Up at **http://localhost:8090**. Wires together: `redis` -> `rpg-api`
+(`AUTH_DEV_MODE=true`, no Discord secrets needed) -> `envoy` (gRPC-Web
+translation, reusing `envoy/envoy.yaml`) -> `nginx` (single entry point,
+`nginx/nginx-local-prod.conf`) -> `rpg-web`. No `.env` required. Redis has no
+volume, so `local-prod-down` + `local-prod` gives you a clean slate.
+
+`nginx-local-prod.conf` is `nginx-local-with-web.conf` minus the `/dnd-api/`
+proxy_pass -- that upstream isn't part of this stack and `DND5E_API_URL` is
+unused by rpg-api's Go code -- and minus nginx's own CORS `add_header` lines
+on the gRPC-Web route, which stacked a second `Access-Control-Allow-Origin`
+on top of the one envoy's own `http.cors` filter already sets, producing an
+invalid multi-value header the moment a caller isn't same-origin (harmless
+normally since real prod traffic is same-origin, but it broke this stack's
+own smoke test below).
+
+### Known limitations of testing the published web image this way
+
+Two characteristics of the published `rpg-dnd5e-web:latest` image mean
+**opening http://localhost:8090 in an ordinary browser will not, by itself,
+exercise this local `rpg-api`** for gRPC calls -- both discovered while
+building this stack, and both baked into the image at CI build time, not
+fixable via env vars or compose config:
+
+1. **The `?playerId=` dev-auth override is compiled out.** `vite build`
+   (what CI runs) bakes `import.meta.env.MODE` to the literal string
+   `"production"`. `src/App.tsx`'s dev-auth override and `src/api/client.ts`'s
+   interceptor branch that attaches `Authorization: Dev <id>` are both gated
+   on `import.meta.env.MODE === 'development'`, so in the published bundle
+   that whole path is dead code -- every gRPC-Web call goes out with no
+   Authorization header at all, which `AUTH_DEV_MODE=true` rpg-api correctly
+   rejects as Unauthenticated.
+2. **`VITE_API_HOST` is baked to the real production domain.** CI
+   (`rpg-dnd5e-web/.github/workflows/docker.yml`) passes `secrets.VITE_API_HOST`
+   as a build arg, which resolves to `https://rpg-toolkit.app`. The bundle
+   therefore calls the *live* production backend directly, not whatever's
+   running next to it -- this is true for `docker-compose.local-dev.yml` too,
+   since it uses the same `:latest` web image.
+
+This stack is still fully correct and useful as-is for verifying image
+provenance (pull it, inspect labels/created date, check the asset tree),
+driving the real `rpg-api:latest` binary directly (`grpcurl`/`curl` with a
+manual `Authorization: Dev <player_id>` header), and confirming the
+envoy/nginx wiring itself works. Getting the *published web bundle* to
+render against this local backend for a full click-through (done for
+rpg-deployment#56's own smoke test, see PR evidence) additionally requires
+intercepting the bundle's `https://rpg-toolkit.app` calls at the network
+layer and redirecting them here -- a Playwright `route.continue()` with a
+local self-signed TLS terminator in front of the stack (needed because
+`route.continue()` requires the override URL to keep the same scheme, and
+because a naive buffering proxy breaks the app's server-streaming RPCs like
+`StreamLobby`/`StreamEncounter`). That workaround lives in the PR's evidence,
+not in this repo, since it's test tooling rather than something the stack
+itself needs to ship.
+
 ## Quick Start
 
 ### Using Pre-built Images (Fastest)

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+.PHONY: local-prod local-prod-down local-prod-logs
+
+# One-command local prod-parity stack (rpg-deployment#56): pulls and runs
+# the exact published production images. See LOCAL_DEV.md for details.
+local-prod:
+	docker compose -f docker-compose.local-prod.yml pull rpg-api rpg-web
+	docker compose -f docker-compose.local-prod.yml up -d
+	@echo ""
+	@echo "Up at http://localhost:8090"
+
+local-prod-down:
+	docker compose -f docker-compose.local-prod.yml down
+
+local-prod-logs:
+	docker compose -f docker-compose.local-prod.yml logs -f

--- a/docker-compose.local-prod.yml
+++ b/docker-compose.local-prod.yml
@@ -1,0 +1,93 @@
+# Local prod-parity stack (rpg-deployment#56).
+#
+# Runs the EXACT published production images -- ghcr.io/kirkdiggler/rpg-api:latest
+# and ghcr.io/kirkdiggler/rpg-dnd5e-web:latest -- behind the same envoy/nginx
+# wiring used elsewhere in this repo, so "what does prod actually run/serve?"
+# can be answered locally instead of guessing from `npm run dev` + `go run`.
+#
+# Usage: make local-prod / make local-prod-down (see Makefile).
+name: rpg-local-prod
+
+services:
+  redis:
+    image: redis:7-alpine
+    container_name: rpg-redis-local-prod
+    restart: unless-stopped
+    expose:
+      - "6379"
+    networks:
+      - rpg-local-prod
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+
+  rpg-api:
+    image: ghcr.io/kirkdiggler/rpg-api:latest
+    container_name: rpg-api-local-prod
+    restart: unless-stopped
+    expose:
+      - "50051"
+    environment:
+      # Published prod image, dev-auth turned on since there's no real Discord
+      # session locally -- see LOCAL_DEV.md for the "Dev <player_id>" scheme
+      # this unlocks and how the web UI is coaxed into using it.
+      - PORT=50051
+      - LOG_LEVEL=info
+      - AUTH_DEV_MODE=true
+      - REDIS_ADDR=redis:6379
+    depends_on:
+      redis:
+        condition: service_healthy
+    networks:
+      - rpg-local-prod
+    healthcheck:
+      test: ["CMD", "/bin/sh", "-c", "nc -z localhost 50051 || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+
+  envoy:
+    image: envoyproxy/envoy:v1.31-latest
+    container_name: rpg-envoy-local-prod
+    restart: unless-stopped
+    expose:
+      - "8080"
+    volumes:
+      - ./envoy/envoy.yaml:/etc/envoy/envoy.yaml:ro
+    depends_on:
+      rpg-api:
+        condition: service_healthy
+    networks:
+      - rpg-local-prod
+    command: /usr/local/bin/envoy -c /etc/envoy/envoy.yaml -l info
+
+  rpg-web:
+    image: ghcr.io/kirkdiggler/rpg-dnd5e-web:latest
+    container_name: rpg-web-local-prod
+    restart: unless-stopped
+    expose:
+      - "80"
+    depends_on:
+      - rpg-api
+    networks:
+      - rpg-local-prod
+
+  nginx-local:
+    image: nginx:alpine
+    container_name: rpg-nginx-local-prod
+    restart: unless-stopped
+    ports:
+      - "8090:80"
+    volumes:
+      - ./nginx/nginx-local-prod.conf:/etc/nginx/nginx.conf:ro
+    depends_on:
+      - envoy
+      - rpg-web
+    networks:
+      - rpg-local-prod
+
+networks:
+  rpg-local-prod:
+    driver: bridge

--- a/nginx/nginx-local-prod.conf
+++ b/nginx/nginx-local-prod.conf
@@ -1,0 +1,74 @@
+events {
+    worker_connections 1024;
+}
+
+# Single entry point for the local prod-parity stack (rpg-deployment#56).
+# Copy of nginx-local-with-web.conf's envoy+web routing, minus the /dnd-api/
+# proxy_pass -- that upstream (ghcr.io/5e-bits/5e-srd-api) isn't part of this
+# stack and DND5E_API_URL is unused by rpg-api's Go code, so keeping a static
+# proxy_pass to a host that doesn't exist here would fail nginx's startup DNS
+# resolution.
+#
+# Also drops nginx-local-with-web.conf's own CORS add_header lines on the
+# gRPC-web location: envoy.yaml's http.cors filter already sets
+# Access-Control-Allow-Origin (echoing the request's Origin) on every
+# response through that route, OPTIONS preflight included. Adding nginx's
+# own static '*' on top doesn't override it -- it appends a second
+# Access-Control-Allow-Origin header, which browsers reject outright
+# ("multiple values ... only one is allowed") the moment a caller is on a
+# different origin than this stack (verified while proxying the published
+# web image's baked-in prod API host through here for rpg-deployment#56's
+# smoke test -- see LOCAL_DEV.md).
+http {
+    upstream rpg_envoy {
+        server envoy:8080;
+    }
+
+    upstream rpg_web {
+        server rpg-web:80;
+    }
+
+    server {
+        listen 80;
+        server_name _;
+
+        # Security headers
+        add_header X-Frame-Options DENY;
+        add_header X-Content-Type-Options nosniff;
+        add_header X-XSS-Protection "1; mode=block";
+
+        # gRPC-Web service routes (all protobuf services)
+        location ~ ^/[a-zA-Z0-9]+(\.[a-zA-Z0-9]+)+/ {
+            proxy_pass http://rpg_envoy;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+
+            # Required for gRPC-Web
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+        }
+
+        # Health check endpoint
+        location /health {
+            access_log off;
+            return 200 "healthy\n";
+            add_header Content-Type text/plain;
+        }
+
+        # React app (published production build)
+        location / {
+            proxy_pass http://rpg_web;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+        }
+    }
+}


### PR DESCRIPTION
— implementer (asset-pipeline), on behalf of KirkDiggler

## What

Closes #56. One command to run the **exact published production images**
locally: `ghcr.io/kirkdiggler/rpg-api:latest` + `ghcr.io/kirkdiggler/rpg-dnd5e-web:latest`,
unmodified, behind the same envoy/nginx wiring already in this repo — so
"what does prod actually run/serve?" can be answered locally in one command
instead of guessing from `npm run dev` + `go run`. Pure wrapper, no new
architecture: reuses `envoy/envoy.yaml` as-is, and `nginx-local-prod.conf`
is `nginx-local-with-web.conf` with the unused `/dnd-api/` route dropped
(that upstream isn't part of this stack, and `DND5E_API_URL` is unused by
rpg-api's Go code — confirmed by grep) plus a CORS fix (below).

```bash
make local-prod       # pulls both :latest images, brings up the stack
make local-prod-logs
make local-prod-down
```

Up at **http://localhost:8090**. `redis` → `rpg-api` (`AUTH_DEV_MODE=true`,
no Discord secrets needed) → `envoy` → `nginx` → `rpg-web`. No `.env`
required, no secrets committed. Documented in `LOCAL_DEV.md` under "Local
Prod-Parity Stack (rpg-deployment#56)".

**Incidental fix**: `nginx-local-prod.conf` drops nginx's own CORS
`add_header` lines on the gRPC-Web route. Envoy's `http.cors` filter
already sets `Access-Control-Allow-Origin` (echoing the request's Origin)
on that route; nginx's static `'*'` add_header on top doesn't replace it,
it appends a second one, which is an invalid multi-value header browsers
reject outright the moment a caller isn't same-origin. Harmless for real
prod traffic (same-origin), but it broke this stack's own smoke test below
until fixed.

## Part 2: driving it for real, and the wall question

Brought the stack up and drove a full flow with Playwright (adapted from
`tools/browser/_job_full_run12.mjs` in the sibling `game-dev` workspace):
character create → draft resume → finalize → lobby create → ready up →
`StartEncounter`. Two build-time characteristics of the published web image
had to be worked around at the network layer to get there — neither is a
code change to the image, both are documented in `LOCAL_DEV.md`:

1. `vite build` bakes `import.meta.env.MODE` to `"production"`, which
   compiles out both the `?playerId=` dev-auth override and the interceptor
   branch that attaches `Authorization: Dev <id>` — every gRPC-Web call the
   real bundle makes goes out with no Authorization header at all.
2. `VITE_API_HOST` is baked at CI build time (`docker.yml`) to the real
   production domain, `https://rpg-toolkit.app` — the bundle calls the live
   backend directly, not whatever's next to it in a compose stack (true for
   `docker-compose.local-dev.yml` too, since it uses the same `:latest`
   image — likely why this had never been driven end-to-end in a browser
   before).

Worked around for the smoke test only (not shipped in this PR) by
intercepting the bundle's `https://rpg-toolkit.app` calls in Playwright and
redirecting them to this local stack, plus a throwaway self-signed local
TLS terminator (needed because `route.continue()`'s URL override must keep
the same scheme, and because a naive buffering proxy hangs the app's
server-streaming RPCs like `StreamLobby`).

### The wall question

**Yes — continuous perimeter walls confirmed**, on a fresh encounter
against the exact published `rpg-api:latest` image.

**Image provenance**: `rpg-api:latest`'s `org.opencontainers.image.revision`
label is `c8322b4df5552cf69aec82c16f36836a19f9b177` — exactly rpg-api's
`origin/main` tip, which is PR #705 ("consume toolkit perimeter edge walls"),
bumping `rpg-toolkit/encounter` v0.40.0 → v0.42.0. Image
`org.opencontainers.image.created` is `2026-07-24T15:32:52Z`, ~2 minutes
after that commit's author timestamp (`2026-07-24T15:30:33Z` UTC) — built
from the merge, not stale.

**Screenshots** (`/home/kirk/.claude/jobs/400b2b51/tmp/prod-parity-verification/`):
- `07-encounter-spawn-wide.png` — wide spawn view. A continuous cyan-edged
  stone wall traces the entire irregular room perimeter, broken only by a
  single corridor opening (bottom-right) — a real door/passage, not a
  generation gap. Two columns, a curved stone prop, and a coiled
  snake/chain relic are visible; diamond-tile floor throughout.
- `08-encounter-wall-closeup.png` — zoomed on the player character at that
  same corridor threshold, showing individual crenellated wall block
  geometry joining cleanly with no visible seams/gaps.
- Also included: `00-home.png`, `01-home-after-reload.png` (draft persisted
  through a hard reload — real Redis-backed rpg-api behavior),
  `02-resumed-draft.png`, `03-after-begin-adventure.png`,
  `04-lobby-entry.png`, `05-lobby-roster.png`, `06-ready.png`.

**Lighting/assets**: dim, moody grey-blue tone consistent with the crypt
theme's baked lighting — no missing-texture artifacts, no blown-out
highlights; walls, floor, columns, and props all rendered from the image's
own baked asset tree.

Known unrelated blocker (movement/Beat-2 sequencer gating, under separate
investigation elsewhere) wasn't fought — these are spawn-view shots only,
per plan.

## Env gotchas

- No Discord secrets needed at all — `AUTH_DEV_MODE=true` is sufficient,
  Discord vars are simply never referenced by this compose file.
- Redis has no volume — `local-prod-down` + `local-prod` is a clean slate
  every time (intentional for a verification stack).
- `DND5E_API_URL` is unused by rpg-api's Go code (grepped, zero hits) —
  the dnd-api/mongo service from other compose files isn't needed here.

## Test plan

- [x] `docker compose -f docker-compose.local-prod.yml config` validates
- [x] `make local-prod` cold-start → both images pulled, all 5 containers
      healthy, `curl localhost:8090/health` → `healthy`
- [x] Full character-create → lobby → StartEncounter flow via Playwright
      against the real images
- [x] `make local-prod-down` tears down cleanly