### PR TITLE
prod default dungeon becomes reference-tomb (authored content) — flips on when a compatible rpg-api image deploys

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -29,6 +29,14 @@ services:
       - LOG_LEVEL=info
       - ENV=production
       - REDIS_ADDR=redis:6379
+      # Default dungeon becomes the Kirk-authored reference-tomb content
+      # (rpg-api#709/#716) instead of the legacy hardcoded crypt -- a no-op
+      # until an rpg-api image embedding reference-tomb.yaml is actually
+      # running (validated at orchestrator construction: an rpg-api image
+      # that doesn't recognize this key fails startup loudly, so this can
+      # only ever be live alongside a compatible image). Instant rollback:
+      # remove this line and redeploy.
+      - RPG_DUNGEON_KEY=reference-tomb
     depends_on:
       - redis
     networks:


### PR DESCRIPTION
Closes #58.

Adds `RPG_DUNGEON_KEY=reference-tomb` to the prod `rpg-api` service in `docker-compose.prod.yml` — the file the "Deploy RPG Platform" workflow's SSM deploy step actually runs (`docker compose -f docker-compose.prod.yml up -d --build` on the EC2 instance, after a `git reset --hard origin/main` in `/opt/rpg-deployment`). This is the only place prod's env comes from; the deploy workflow's own `.env` only carries Discord/domain secrets, nothing dungeon-related.

**No-op until a compatible rpg-api image deploys.** `RPG_DUNGEON_KEY` is validated at orchestrator construction (rpg-api#709's Task E2b) — an older rpg-api image that doesn't recognize this env var at all just never reads it (unknown env vars are harmless); once an image that DOES read it deploys, it must resolve to a real, enabled dungeon key or the api container fails to start, so this can't silently degrade.

**One nuance worth being precise about, since issue #58 was filed referencing #710 specifically:** rpg-api#710 (merged) shipped the `RPG_DUNGEON_KEY` mechanism itself plus reference-tomb's *original* 2-room content. The 3-room version Kirk actually walked, fought, and approved live ("lands playable" per this issue's own framing) ships separately in rpg-api#718 (open as of this PR). If this flip goes live between #710 and #718 deploying, players get the mechanism working correctly but against the plainer 2-room draft, not the approved 3-room one. Merging this PR is safe either way (both are real, valid content) — just flagging that "playable" in the sense Kirk meant requires #718's image specifically, not #710 alone.

**Instant rollback:** remove the `RPG_DUNGEON_KEY` line and redeploy — the legacy hardcoded crypt returns as the default immediately.

— implementer (asset-pipeline), on behalf of KirkDiggler
