### PR TITLE
feat: parallel lab api instance for local dev

### DIFF
--- a/docker-compose.local-lab.yml
+++ b/docker-compose.local-lab.yml
@@ -1,12 +1,14 @@
-# Overlay adding a SECOND, parallel api instance for local labs/experiments —
-# so one team's dungeon-key/content swap on the shared rpg-api container
-# stops colliding with another team's playtest (Kirk: "can we run our api
-# server separate from what the other teams are doing?").
+# Overlay adding PARALLEL api instances for local labs/experiments — so one
+# team's dungeon-key/content swap on the shared rpg-api container stops
+# colliding with another team's playtest (Kirk: "can we run our api server
+# separate from what the other teams are doing?").
 #
-# This file adds `rpg-api-lab` + `envoy-lab`; it never touches the existing
-# `rpg-api`/`envoy` services from docker-compose.local-dev.yml. The primary
-# stays the stable, shared baseline (reference-tomb) for everyone — labs and
-# experiments run here instead.
+# This file adds `rpg-api-lab`/`envoy-lab` (:8081) and `rpg-api-lab2`/
+# `envoy-lab2` (:8082); it never touches the existing `rpg-api`/`envoy`
+# services from docker-compose.local-dev.yml. The primary stays the stable,
+# shared baseline (reference-tomb) for everyone — labs and experiments run
+# here instead. Two named instances is enough for now — see "More than two
+# instances" below if a third is ever needed.
 #
 # Usage (from rpg-deployment/, alongside the normal primary-stack commands):
 #   docker build -t rpg-api:local ../rpg-api   # same image tag the primary
@@ -14,15 +16,39 @@
 #                                               # skip this if already built
 #   docker compose -f docker-compose.local-dev.yml \
 #                  -f docker-compose.local-lab.yml up -d rpg-api-lab envoy-lab
+#   # and/or, independently:
+#   docker compose -f docker-compose.local-dev.yml \
+#                  -f docker-compose.local-lab.yml up -d rpg-api-lab2 envoy-lab2
 #
 # Web-side hookup: rpg-dnd5e-web/vite.config.ts's /connect proxy already
 # reads VITE_API_HOST (falls back to localhost:8080) — no web-repo change
-# needed. Point a worktree's dev server at the lab instance with:
-#   VITE_API_HOST=http://localhost:8081 npm run dev
+# needed. Point a worktree's dev server at a lab instance with:
+#   VITE_API_HOST=http://localhost:8081 npm run dev   # lab1
+#   VITE_API_HOST=http://localhost:8082 npm run dev   # lab2
 #
 # Content/dungeon-key knobs (override per shell, none hardcoded to a machine):
-#   RPG_LAB_DUNGEON_KEY   - default dungeon key for the lab instance (default: wall-lab)
-#   RPG_CONTENT_HOST_DIR  - host dir mounted read-only at /content (default: ../dungeon-content)
+#   RPG_LAB_DUNGEON_KEY   - default dungeon key for lab1 (default: wall-lab)
+#   RPG_LAB2_DUNGEON_KEY  - default dungeon key for lab2 (default: look-lab)
+#   RPG_CONTENT_HOST_DIR  - host dir mounted read-only at /content on BOTH
+#                           lab instances (default: ../dungeon-content)
+#
+# Defaults above just mirror whatever experiment happened to be current when
+# each lab instance was added — not meant to be permanent names. Override
+# per shell for a new experiment; no need to edit this file.
+#
+# More than two instances: if a third lab is ever needed, promote the
+# per-service blocks below into a compose fragment templated by instance
+# name/port/env-var-prefix (docker compose doesn't cleanly template full
+# service blocks via YAML anchors once `environment` needs a per-instance
+# key — anchors only help with blocks that are byte-identical across
+# instances, like the healthcheck below). Two hand-written instances isn't
+# worth that machinery yet.
+
+x-rpg-api-lab-healthcheck: &rpg-api-lab-healthcheck
+  test: ["CMD", "/bin/sh", "-c", "nc -z localhost 50051 || exit 1"]
+  interval: 10s
+  timeout: 5s
+  retries: 3
 
 services:
   rpg-api-lab:
@@ -46,11 +72,7 @@ services:
       - dnd-api
     networks:
       - rpg-network
-    healthcheck:
-      test: ["CMD", "/bin/sh", "-c", "nc -z localhost 50051 || exit 1"]
-      interval: 10s
-      timeout: 5s
-      retries: 3
+    healthcheck: *rpg-api-lab-healthcheck
 
   envoy-lab:
     image: envoyproxy/envoy:v1.31-latest
@@ -63,6 +85,44 @@ services:
       - ./envoy/envoy-lab.yaml:/etc/envoy/envoy.yaml:ro
     depends_on:
       - rpg-api-lab
+    networks:
+      - rpg-network
+    command: /usr/local/bin/envoy -c /etc/envoy/envoy.yaml -l info
+
+  rpg-api-lab2:
+    image: rpg-api:local
+    pull_policy: never
+    container_name: rpg-api-lab2
+    expose:
+      - "50051"  # Only expose internally to Docker network
+    environment:
+      - PORT=50051
+      - LOG_LEVEL=info
+      - REDIS_ADDR=redis:6379
+      - AUTH_DEV_MODE=true
+      - DND5E_API_URL=http://dnd-api:3000/api/2014/
+      - RPG_DUNGEON_KEY=${RPG_LAB2_DUNGEON_KEY:-look-lab}
+      - RPG_CONTENT_DIR=/content
+    volumes:
+      - ${RPG_CONTENT_HOST_DIR:-../dungeon-content}:/content:ro
+    depends_on:
+      - redis
+      - dnd-api
+    networks:
+      - rpg-network
+    healthcheck: *rpg-api-lab-healthcheck
+
+  envoy-lab2:
+    image: envoyproxy/envoy:v1.31-latest
+    container_name: rpg-envoy-lab2
+    ports:
+      - "8082:8080"  # host-accessible for a worktree's VITE_API_HOST override
+    expose:
+      - "9901"  # Admin interface only internal
+    volumes:
+      - ./envoy/envoy-lab2.yaml:/etc/envoy/envoy.yaml:ro
+    depends_on:
+      - rpg-api-lab2
     networks:
       - rpg-network
     command: /usr/local/bin/envoy -c /etc/envoy/envoy.yaml -l info

--- a/docker-compose.local-lab.yml
+++ b/docker-compose.local-lab.yml
@@ -1,0 +1,68 @@
+# Overlay adding a SECOND, parallel api instance for local labs/experiments —
+# so one team's dungeon-key/content swap on the shared rpg-api container
+# stops colliding with another team's playtest (Kirk: "can we run our api
+# server separate from what the other teams are doing?").
+#
+# This file adds `rpg-api-lab` + `envoy-lab`; it never touches the existing
+# `rpg-api`/`envoy` services from docker-compose.local-dev.yml. The primary
+# stays the stable, shared baseline (reference-tomb) for everyone — labs and
+# experiments run here instead.
+#
+# Usage (from rpg-deployment/, alongside the normal primary-stack commands):
+#   docker build -t rpg-api:local ../rpg-api   # same image tag the primary
+#                                               # local-api-src overlay uses;
+#                                               # skip this if already built
+#   docker compose -f docker-compose.local-dev.yml \
+#                  -f docker-compose.local-lab.yml up -d rpg-api-lab envoy-lab
+#
+# Web-side hookup: rpg-dnd5e-web/vite.config.ts's /connect proxy already
+# reads VITE_API_HOST (falls back to localhost:8080) — no web-repo change
+# needed. Point a worktree's dev server at the lab instance with:
+#   VITE_API_HOST=http://localhost:8081 npm run dev
+#
+# Content/dungeon-key knobs (override per shell, none hardcoded to a machine):
+#   RPG_LAB_DUNGEON_KEY   - default dungeon key for the lab instance (default: wall-lab)
+#   RPG_CONTENT_HOST_DIR  - host dir mounted read-only at /content (default: ../dungeon-content)
+
+services:
+  rpg-api-lab:
+    image: rpg-api:local
+    pull_policy: never
+    container_name: rpg-api-lab
+    expose:
+      - "50051"  # Only expose internally to Docker network
+    environment:
+      - PORT=50051
+      - LOG_LEVEL=info
+      - REDIS_ADDR=redis:6379
+      - AUTH_DEV_MODE=true
+      - DND5E_API_URL=http://dnd-api:3000/api/2014/
+      - RPG_DUNGEON_KEY=${RPG_LAB_DUNGEON_KEY:-wall-lab}
+      - RPG_CONTENT_DIR=/content
+    volumes:
+      - ${RPG_CONTENT_HOST_DIR:-../dungeon-content}:/content:ro
+    depends_on:
+      - redis
+      - dnd-api
+    networks:
+      - rpg-network
+    healthcheck:
+      test: ["CMD", "/bin/sh", "-c", "nc -z localhost 50051 || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+
+  envoy-lab:
+    image: envoyproxy/envoy:v1.31-latest
+    container_name: rpg-envoy-lab
+    ports:
+      - "8081:8080"  # host-accessible for a worktree's VITE_API_HOST override
+    expose:
+      - "9901"  # Admin interface only internal
+    volumes:
+      - ./envoy/envoy-lab.yaml:/etc/envoy/envoy.yaml:ro
+    depends_on:
+      - rpg-api-lab
+    networks:
+      - rpg-network
+    command: /usr/local/bin/envoy -c /etc/envoy/envoy.yaml -l info

--- a/envoy/envoy-lab.yaml
+++ b/envoy/envoy-lab.yaml
@@ -47,7 +47,7 @@ static_resources:
                         allow_origin_string_match:
                           - prefix: "*"
                         allow_methods: GET, PUT, DELETE, POST, OPTIONS
-                        allow_headers: keep-alive,user-agent,cache-control,content-type,content-transfer-encoding,custom-header-1,x-accept-content-transfer-encoding,x-accept-response-streaming,x-user-agent,x-grpc-web,grpc-timeout,connect-protocol-version,connect-timeout-ms,connect-accept-encoding,connect-content-encoding
+                        allow_headers: keep-alive,user-agent,cache-control,content-type,content-transfer-encoding,custom-header-1,x-accept-content-transfer-encoding,x-accept-response-streaming,x-user-agent,x-grpc-web,grpc-timeout,connect-protocol-version,connect-timeout-ms,connect-accept-encoding,connect-content-encoding,authorization
                         max_age: "1728000"
                         expose_headers: grpc-status,grpc-message
                 http_filters:

--- a/envoy/envoy-lab.yaml
+++ b/envoy/envoy-lab.yaml
@@ -1,0 +1,90 @@
+# Envoy config for the parallel lab api instance (docker-compose.local-lab.yml).
+# Identical routing/CORS to envoy/envoy.yaml — the only difference is the
+# grpc_service cluster below, which targets rpg-api-lab instead of rpg-api.
+# Keep the two files in sync for anything other than that cluster address.
+
+admin:
+  address:
+    socket_address:
+      address: 0.0.0.0
+      port_value: 9901
+
+static_resources:
+  listeners:
+    - name: listener_0
+      address:
+        socket_address:
+          address: 0.0.0.0
+          port_value: 8080
+      filter_chains:
+        - filters:
+            - name: envoy.filters.network.http_connection_manager
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                codec_type: auto
+                stat_prefix: ingress_http
+                route_config:
+                  name: local_route
+                  virtual_hosts:
+                    - name: local_service
+                      domains: ["*"]
+                      routes:
+                        - match:
+                            prefix: "/dnd-api/"
+                          route:
+                            cluster: dnd_api_service
+                            timeout: 0s
+                            prefix_rewrite: "/api/"
+                        - match:
+                            prefix: "/"
+                          route:
+                            cluster: grpc_service
+                            timeout: 0s
+                            max_stream_duration:
+                              grpc_timeout_header_max: 0s
+                      cors:
+                        allow_origin_string_match:
+                          - prefix: "*"
+                        allow_methods: GET, PUT, DELETE, POST, OPTIONS
+                        allow_headers: keep-alive,user-agent,cache-control,content-type,content-transfer-encoding,custom-header-1,x-accept-content-transfer-encoding,x-accept-response-streaming,x-user-agent,x-grpc-web,grpc-timeout,connect-protocol-version,connect-timeout-ms,connect-accept-encoding,connect-content-encoding
+                        max_age: "1728000"
+                        expose_headers: grpc-status,grpc-message
+                http_filters:
+                  - name: envoy.filters.http.grpc_web
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.grpc_web.v3.GrpcWeb
+                  - name: envoy.filters.http.cors
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.cors.v3.Cors
+                  - name: envoy.filters.http.router
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+
+  clusters:
+    - name: grpc_service
+      type: logical_dns
+      connect_timeout: 0.25s
+      http2_protocol_options: {}
+      lb_policy: round_robin
+      load_assignment:
+        cluster_name: grpc_service
+        endpoints:
+          - lb_endpoints:
+              - endpoint:
+                  address:
+                    socket_address:
+                      address: rpg-api-lab  # Docker service name (lab instance)
+                      port_value: 50051
+    - name: dnd_api_service
+      type: logical_dns
+      connect_timeout: 0.25s
+      lb_policy: round_robin
+      load_assignment:
+        cluster_name: dnd_api_service
+        endpoints:
+          - lb_endpoints:
+              - endpoint:
+                  address:
+                    socket_address:
+                      address: dnd-api  # Docker service name
+                      port_value: 3000

--- a/envoy/envoy-lab2.yaml
+++ b/envoy/envoy-lab2.yaml
@@ -47,7 +47,7 @@ static_resources:
                         allow_origin_string_match:
                           - prefix: "*"
                         allow_methods: GET, PUT, DELETE, POST, OPTIONS
-                        allow_headers: keep-alive,user-agent,cache-control,content-type,content-transfer-encoding,custom-header-1,x-accept-content-transfer-encoding,x-accept-response-streaming,x-user-agent,x-grpc-web,grpc-timeout,connect-protocol-version,connect-timeout-ms,connect-accept-encoding,connect-content-encoding
+                        allow_headers: keep-alive,user-agent,cache-control,content-type,content-transfer-encoding,custom-header-1,x-accept-content-transfer-encoding,x-accept-response-streaming,x-user-agent,x-grpc-web,grpc-timeout,connect-protocol-version,connect-timeout-ms,connect-accept-encoding,connect-content-encoding,authorization
                         max_age: "1728000"
                         expose_headers: grpc-status,grpc-message
                 http_filters:

--- a/envoy/envoy-lab2.yaml
+++ b/envoy/envoy-lab2.yaml
@@ -1,6 +1,6 @@
-# Envoy config for the first parallel lab api instance (docker-compose.local-lab.yml).
+# Envoy config for the second parallel lab api instance (docker-compose.local-lab.yml).
 # Identical routing/CORS to envoy/envoy.yaml — the only difference is the
-# grpc_service cluster below, which targets rpg-api-lab instead of rpg-api.
+# grpc_service cluster below, which targets rpg-api-lab2 instead of rpg-api.
 # Keep the three envoy configs (envoy.yaml, envoy-lab.yaml, envoy-lab2.yaml) in
 # sync for anything other than each one's cluster address.
 
@@ -74,7 +74,7 @@ static_resources:
               - endpoint:
                   address:
                     socket_address:
-                      address: rpg-api-lab  # Docker service name (lab instance)
+                      address: rpg-api-lab2  # Docker service name (second lab instance)
                       port_value: 50051
     - name: dnd_api_service
       type: logical_dns


### PR DESCRIPTION
Closes #60.

## Summary

Parallel local api instances so teams stop colliding on the shared
`rpg-api` container's `RPG_DUNGEON_KEY`/`RPG_CONTENT_DIR` (Kirk: "can we run
our api server separate from what the other teams are doing?"). The primary
stays the stable, shared baseline (reference-tomb) for everyone; labs and
experiments run on these parallel instances instead.

- `docker-compose.local-lab.yml` — new overlay, adds `rpg-api-lab` (image
  `rpg-api:local`, same tag the primary's `local-api-src` overlay already
  uses) with its own `RPG_DUNGEON_KEY` (default `wall-lab`, override via
  `RPG_LAB_DUNGEON_KEY`) and its own `RPG_CONTENT_DIR` mount (host dir
  parameterized via `RPG_CONTENT_HOST_DIR`, default `../dungeon-content` —
  not hardcoded to one machine). Shares the existing
  network/redis/mongo/5e-srd-api services from `docker-compose.local-dev.yml`;
  never touches the primary `rpg-api`/`envoy` services.
- `envoy/envoy-lab.yaml` + `envoy-lab` service — identical routing/CORS to
  `envoy/envoy.yaml`, clustering to `rpg-api-lab` instead of `rpg-api`, on
  host port **8081** (primary stays on 8080).
- `AUTH_DEV_MODE=true` on the lab instance for local dev-auth convenience —
  matches what the primary already runs locally (not yet committed there;
  out of scope for this PR).

## Second lab instance (added after initial review): rpg-api-lab2 / :8082

Kirk wants to walk a props/lighting experiment (`dungeon-content/look-lab.yaml`,
key `look-lab`, already validated) while the wall audit keeps lab1 on
`wall-lab` — one lab instance wasn't enough for two concurrent experiments.

- `rpg-api-lab2` + `envoy-lab2`, same pattern as lab1: own `RPG_DUNGEON_KEY`
  (default `look-lab`, override via `RPG_LAB2_DUNGEON_KEY`), same
  `RPG_CONTENT_DIR` mount as lab1 (one host dir holds both `wall-lab.yaml`
  and `look-lab.yaml`), host port **8082**.
- Both lab defaults (`wall-lab`, `look-lab`) just mirror whichever
  experiment was current when each instance was added, not permanent names
  — override per shell for the next one.
- Small de-dup, not a template system: the byte-identical healthcheck block
  is now one YAML anchor (`x-rpg-api-lab-healthcheck`) shared by both lab
  services. Two hand-written instances doesn't justify more machinery than
  that — the file header notes the N-instances idea (a templated fragment;
  compose can't cleanly anchor the `environment` list once each instance
  needs its own dungeon-key var) for whenever a third is needed.

## Web-side hookup (no rpg-dnd5e-web change needed)

`vite.config.ts`'s `/connect` proxy already reads `process.env.VITE_API_HOST`
(falls back to `localhost:8080`) — already exactly what this needs. A
worktree points its dev server at a lab instance with:

```bash
VITE_API_HOST=http://localhost:8081 npm run dev   # lab1
VITE_API_HOST=http://localhost:8082 npm run dev   # lab2
```

Doc follow-up (separate small PR, rpg-project#152): `docs/howto/run-the-game-locally.md`
gets a "Parallel lab api" section covering when to use it, the compose
command, and the vite hookup line above.

## Commands

```bash
docker build -t rpg-api:local ../rpg-api   # skip if already built

docker compose -f docker-compose.local-dev.yml \
               -f docker-compose.local-lab.yml up -d rpg-api-lab envoy-lab
# and/or, independently:
docker compose -f docker-compose.local-dev.yml \
               -f docker-compose.local-lab.yml up -d rpg-api-lab2 envoy-lab2
```

## Verification (live, on this machine, alongside the running primary stack)

**Lab1:**
- [x] Primary untouched throughout: `rpg-api`'s `StartedAt` and
  `RPG_DUNGEON_KEY` (`wall-lab`) unchanged before/after; primary continued
  serving on :8080 the whole time.
- [x] `rpg-api-lab` + `envoy-lab` came up clean, joined the existing
  `rpg-deployment_rpg-network`, connected to the shared redis/dnd-api —
  neither of those services was recreated.
- [x] grpcurl reflection through `:8081` lists the same service set, served
  by a distinct container (`rpg-api-lab`, not `rpg-api`).
- [x] Independent per-container dungeon-key resolution: setting
  `RPG_LAB_DUNGEON_KEY=totally-bogus-key-xyz` makes **only** the lab
  instance fail fast at construction (`RPG_DUNGEON_KEY "totally-bogus-key-xyz"
  does not resolve...`, the #709/#710 `validateDungeonKeyOverride` path) while
  the primary keeps running unaffected; reverting to the default brings the
  lab instance back up healthy.
- [x] Full application-layer round trip through `:8081`: `grpcurl` `CreateLobby`
  with a nonexistent `character_id` returns `NotFound: character not found`
  from the lab instance's own orchestrator/repository layer — proving real
  routing, not just a TCP-level echo.

**Lab2 (added after initial review):**
- [x] Primary and lab1 untouched throughout: both containers' `StartedAt`
  unchanged, lab1 stayed on `wall-lab`, across the entire lab2 sequence.
- [x] `rpg-api-lab2` + `envoy-lab2` came up clean with
  `RPG_LAB2_DUNGEON_KEY=look-lab`; grpcurl reflection through `:8082` lists
  the same service set via a distinct container.
- [x] Independent per-instance resolution: `RPG_LAB2_DUNGEON_KEY=totally-bogus-lab2-key`
  makes only lab2 fail fast at construction, primary/lab1 unaffected;
  reverting to `look-lab` brings lab2 back up healthy.
- [x] Full application-layer round trip through `:8082`: `grpcurl` `CreateLobby`
  with a nonexistent `character_id` returns `NotFound: character not found`
  from lab2's own orchestrator/repository layer.

— asset-pipeline agent, on behalf of KirkDiggler