### PR TITLE
feat: commit the local dev stack and default rpg-api to the dev image

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,3 +13,7 @@ DISCORD_CLIENT_SECRET=your-discord-client-secret
 # PORT=50051
 # LOG_LEVEL=info
 # REDIS_URL=redis://redis:6379
+
+# Local dev only (docker-compose.local-dev.yml): which rpg-api image tag to
+# pull. Defaults to `dev` (the integration branch image). See ENV_SETUP.md.
+# RPG_API_IMAGE_TAG=dev

--- a/ENV_SETUP.md
+++ b/ENV_SETUP.md
@@ -48,6 +48,19 @@ LOG_LEVEL=info
 REDIS_URL=redis://redis:6379
 ```
 
+## Local Dev Overrides
+
+These only apply when running `docker-compose.local-dev.yml` (they're not read by
+the production compose files):
+
+```bash
+# Which rpg-api image tag the local dev stack pulls. Defaults to `dev` — the
+# integration branch image, published by rpg-api's docker workflow on every
+# push to `dev`. Override to pin a different tag, e.g. `latest` (what's in
+# production) or a specific commit sha.
+RPG_API_IMAGE_TAG=dev
+```
+
 ## Security Notes
 
 1. **Never commit `.env` to git** - It's in .gitignore for a reason

--- a/docker-compose.fog-lab-env.yml
+++ b/docker-compose.fog-lab-env.yml
@@ -1,0 +1,23 @@
+# Overlay for docker-compose.local-dev.yml + docker-compose.local-api-src.yml
+# that sets RPG_DUNGEON_KEY for the local rpg-api container, selecting the
+# fog-lab dungeon fixture (rpg-project#733 follow-up: a purpose-built dungeon
+# for fog-of-war playtesting) instead of the live default (the procedural
+# crypt generator).
+#
+# A separate file rather than editing docker-compose.local-api-src.yml or
+# docker-compose.local-dev.yml in place — both already carry local uncommitted
+# edits.
+#
+# Usage (after `docker build -t rpg-api:local <rpg-api worktree>`):
+#   docker compose -f docker-compose.local-dev.yml \
+#                  -f docker-compose.local-api-src.yml \
+#                  -f docker-compose.fog-lab-env.yml up -d rpg-api
+#
+# To go back to the live default dungeon, redeploy without this file:
+#   docker compose -f docker-compose.local-dev.yml \
+#                  -f docker-compose.local-api-src.yml up -d rpg-api
+
+services:
+  rpg-api:
+    environment:
+      - RPG_DUNGEON_KEY=fog-lab

--- a/docker-compose.local-api-src.yml
+++ b/docker-compose.local-api-src.yml
@@ -1,0 +1,24 @@
+# Overlay for docker-compose.local-dev.yml that swaps the prebuilt
+# ghcr.io/kirkdiggler/rpg-api:latest image for one built from the local
+# ../rpg-api working tree. Everything else (redis, mongo, 5e-srd-api,
+# envoy, nginx) stays on the prebuilt images from local-dev.yml.
+#
+# Why an overlay instead of docker-compose.local-src.yml: that file also
+# containerizes rpg-dnd5e-web, which kills Vite HMR (read-only mount, no
+# node_modules) and puts a Docker rebuild in the middle of every UI tweak.
+# The fast loop is containers for the backend, `npm run dev` on the host.
+#
+# Usage:
+#   # once, after changing rpg-api source:
+#   docker build -t rpg-api:local ../rpg-api
+#   # then:
+#   docker compose -f docker-compose.local-dev.yml \
+#                  -f docker-compose.local-api-src.yml up -d rpg-api
+#
+# The web app is served by `npm run dev` in ../rpg-dnd5e-web (port 3001);
+# its /connect proxy already targets envoy on localhost:8080.
+
+services:
+  rpg-api:
+    image: rpg-api:local
+    pull_policy: never

--- a/docker-compose.local-dev.yml
+++ b/docker-compose.local-dev.yml
@@ -48,7 +48,10 @@ services:
       retries: 3
 
   rpg-api:
-    image: ghcr.io/kirkdiggler/rpg-api:latest
+    # `dev` is the integration branch image, published by rpg-api's docker
+    # workflow on every push to `dev`. Override RPG_API_IMAGE_TAG to pin a
+    # different tag (e.g. `latest` for what's in production, or a sha).
+    image: ghcr.io/kirkdiggler/rpg-api:${RPG_API_IMAGE_TAG:-dev}
     container_name: rpg-api
     expose:
       - "50051"  # Only expose internally to Docker network
@@ -56,6 +59,7 @@ services:
       - PORT=50051
       - LOG_LEVEL=info
       - REDIS_ADDR=redis:6379
+      - AUTH_DEV_MODE=true
       - DND5E_API_URL=http://dnd-api:3000/api/2014/
     depends_on:
       - redis
@@ -71,8 +75,9 @@ services:
   envoy:
     image: envoyproxy/envoy:v1.31-latest
     container_name: rpg-envoy
+    ports:
+      - "8080:8080"  # host-accessible for the web dev-server's /connect proxy
     expose:
-      - "8080"  # Only expose internally to Docker network
       - "9901"  # Admin interface only internal
     volumes:
       - ./envoy/envoy.yaml:/etc/envoy/envoy.yaml:ro


### PR DESCRIPTION
Closes #63.

## Summary

The local playtest stack's definition was previously **unversioned**: `docker-compose.local-dev.yml` and `envoy/envoy.yaml` carried uncommitted edits, and two overlays (`docker-compose.local-api-src.yml`, `docker-compose.fog-lab-env.yml`) were untracked entirely. `bootstrap.sh` could not reproduce Kirk's playtest environment from a fresh clone.

rpg-api now has a long-lived `dev` branch whose `.github/workflows/docker.yml` already has `type=ref,event=branch` in docker/metadata-action, so pushing `dev` publishes `ghcr.io/kirkdiggler/rpg-api:dev`. This PR also switches the local stack's default image to that tag, so "what am I playing?" is answerable from the branch name instead of everyone hand-building.

## Changes

- **`docker-compose.local-dev.yml`**
  - `rpg-api` gets `AUTH_DEV_MODE=true` (local-dev convenience; this compose file is exclusively the LOCAL DEV stack — production runs entirely separate compose files: `docker-compose.yml`, `docker-compose.dnd.yml`, and rpg-deployment's own `.github/workflows/deploy.yml` AWS path).
  - `envoy` moves from internal-only `expose: - "8080"` to `ports: - "8080:8080"` (host-accessible for the web dev-server's `/connect` proxy), keeping `expose: - "9901"` admin-only.
  - `rpg-api`'s image becomes `ghcr.io/kirkdiggler/rpg-api:${RPG_API_IMAGE_TAG:-dev}` — defaults to the CI-published `dev` integration image; override `RPG_API_IMAGE_TAG` to pin `latest` (production) or a specific sha.
- **`docker-compose.local-api-src.yml`** (new, previously untracked) — the existing overlay that swaps the pulled image for a locally-built `rpg-api:local`. Remains available and opt-in.
- **`docker-compose.fog-lab-env.yml`** (new, previously untracked) — the existing fog-lab dungeon-key overlay.
- **`ENV_SETUP.md` / `.env.example`** — document `RPG_API_IMAGE_TAG`.

`envoy/envoy.yaml`'s pending CORS `authorization` header edit is **not** in this diff — it turned out to already be on `main` (landed via #55 before this branch was cut), so there was nothing left to commit there.

## Explicitly out of scope

Multi-lab support (`docker-compose.local-lab.yml`, `envoy/envoy-lab.yaml`, `envoy/envoy-lab2.yaml`) already shipped separately in #61 — not touched here. One instance, one port for the primary stack, per Kirk's direction.

## Test plan

- [x] `docker compose -f docker-compose.local-dev.yml config` parses cleanly; `rpg-api` resolves to `ghcr.io/kirkdiggler/rpg-api:dev`
- [x] `docker compose -f docker-compose.local-dev.yml -f docker-compose.local-api-src.yml config` parses cleanly; `rpg-api` resolves to `rpg-api:local` (overlay still wins)
- [x] Diffed against Kirk's own working-tree edits to the two previously-tracked files — this PR's version differs only by the image-tag change (his edits are otherwise identical, and become redundant once this merges)

— asset-pipeline agent, on behalf of KirkDiggler