### PR TITLE
feat: add isolated toolkit override lab

### DIFF
--- a/LOCAL_DEV.md
+++ b/LOCAL_DEV.md
@@ -126,9 +126,12 @@ scripts/toolkit-override-lab.sh down \
 
 `down` is idempotent. It removes only the two name-scoped containers, their
 lab-specific API image, and the generated Envoy config; invokes the API
-helper's `off` path; and fails loudly if `go.mod` or `local-toolkit/` residue
-remains. The lab shares the existing Redis dependency, so tests that create
-fixture keys still own deletion of those keys.
+helper's `off` path; and verifies each resource and all override residue are
+absent before reporting success. Startup failures follow the same verified
+rollback, including when the helper mutates and then fails; an approved
+override that was already active before `up` is restored byte-for-byte instead
+of being removed. The lab shares the existing Redis dependency, so tests that
+create fixture keys still own deletion of those keys.
 
 Collision failures are intentional. Do not remove or rename someone else's
 container: choose another `--name` or port. `--network` can override the

--- a/LOCAL_DEV.md
+++ b/LOCAL_DEV.md
@@ -70,6 +70,77 @@ because a naive buffering proxy breaks the app's server-streaming RPCs like
 not in this repo, since it's test tooling rather than something the stack
 itself needs to ship.
 
+## Which local environment to use
+
+Treat the primary stack (`rpg-api` / `rpg-envoy`, normally `:8080`) as the
+shared stable baseline. Do not redeploy it for an experiment while another
+session may be using it. The fixed `lab` and `lab2` services on `:8081` and
+`:8082` are shared playtest slots; use them only when you have coordinated
+ownership of that slot.
+
+For an unpublished `rpg-toolkit/encounter` change, use the isolated wrapper
+below instead of following `rpg-api`'s standalone override guide all the way
+to its primary-container redeploy example. The API guide remains authoritative
+for how its single-module override works; this wrapper invokes that helper and
+owns the safe Docker lifecycle around it.
+
+### Isolated toolkit-override lab
+
+Prerequisites:
+
+- Docker, `curl`, and Python 3 available locally;
+- fresh/dispensable API worktree with `Dockerfile.local-toolkit` and
+  `scripts/toolkit-local-override.sh`;
+- toolkit worktree containing the unpublished `encounter` change;
+- the normal local dependency stack already running, including the Docker
+  network `rpg-deployment_rpg-network`, Redis, and the D&D API;
+- unused Envoy and (optionally) Vite ports.
+
+From this repository:
+
+```bash
+scripts/toolkit-override-lab.sh up \
+  --api /path/to/rpg-api-worktree \
+  --toolkit /path/to/rpg-toolkit-worktree \
+  --name movement-893 \
+  --envoy-port 8183 \
+  --vite-port 5183
+```
+
+The command validates the worktrees, lab name, Docker network, container
+names, and ports before touching the API worktree. It then invokes the
+existing API override helper, verifies that only the approved `encounter`
+module is active, builds with `Dockerfile.local-toolkit`, and starts uniquely
+named API and Envoy containers. It prints the API URL, exact Vite command,
+and cleanup command. It never runs Compose and therefore never recreates the
+primary, `lab`, or `lab2` services.
+
+After each toolkit edit, cleanly cycle the lab and run `up` again so the
+existing override helper re-syncs the source:
+
+```bash
+scripts/toolkit-override-lab.sh down \
+  --api /path/to/rpg-api-worktree --name movement-893
+# then repeat the up command
+```
+
+`down` is idempotent. It removes only the two name-scoped containers, their
+lab-specific API image, and the generated Envoy config; invokes the API
+helper's `off` path; and fails loudly if `go.mod` or `local-toolkit/` residue
+remains. The lab shares the existing Redis dependency, so tests that create
+fixture keys still own deletion of those keys.
+
+Collision failures are intentional. Do not remove or rename someone else's
+container: choose another `--name` or port. `--network` can override the
+network name when the dependency stack was started under another Compose
+project.
+
+Run the wrapper regression suite with:
+
+```bash
+make test
+```
+
 ## Quick Start
 
 ### Using Pre-built Images (Fastest)

--- a/LOCAL_DEV_WORKFLOW.md
+++ b/LOCAL_DEV_WORKFLOW.md
@@ -1,10 +1,16 @@
 # Local Development Workflow
 
-This document describes how to run the RPG platform locally for development, matching the actual development workflow.
+This document describes the legacy individual-service and full-stack flows.
+For environment ownership and the supported isolated toolkit-override lab, read
+[LOCAL_DEV.md](LOCAL_DEV.md#which-local-environment-to-use) first. The primary
+`:8080` environment is the shared stable baseline; experiments must use an
+owned fixed lab or the isolated wrapper, never silently redeploy primary.
 
-## Option 1: Individual Services (Like Current Dev Workflow)
+## Option 1: Individual Services (coordinated primary work only)
 
-This matches how you currently develop locally:
+Use this only when you intentionally own the primary environment. It is not
+the safe path for an unpublished toolkit experiment; use the isolated wrapper
+in `LOCAL_DEV.md` for that.
 
 ### Prerequisites
 - Redis running on localhost:6379

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: local-prod local-prod-down local-prod-logs
+.PHONY: local-prod local-prod-down local-prod-logs test
 
 # One-command local prod-parity stack (rpg-deployment#56): pulls and runs
 # the exact published production images. See LOCAL_DEV.md for details.
@@ -13,3 +13,7 @@ local-prod-down:
 
 local-prod-logs:
 	docker compose -f docker-compose.local-prod.yml logs -f
+
+# Deployment-tooling regression checks (no live containers are started).
+test:
+	./scripts/test-toolkit-override-lab.sh

--- a/docker-compose.local-lab.yml
+++ b/docker-compose.local-lab.yml
@@ -41,8 +41,9 @@
 # name/port/env-var-prefix (docker compose doesn't cleanly template full
 # service blocks via YAML anchors once `environment` needs a per-instance
 # key — anchors only help with blocks that are byte-identical across
-# instances, like the healthcheck below). Two hand-written instances isn't
-# worth that machinery yet.
+# instances, like the healthcheck below). Do not hand-add a toolkit-override
+# experiment here: scripts/toolkit-override-lab.sh creates a name-scoped API +
+# Envoy pair without claiming either fixed lab or recreating the primary stack.
 
 x-rpg-api-lab-healthcheck: &rpg-api-lab-healthcheck
   test: ["CMD", "/bin/sh", "-c", "nc -z localhost 50051 || exit 1"]

--- a/scripts/test-toolkit-override-lab.sh
+++ b/scripts/test-toolkit-override-lab.sh
@@ -14,7 +14,11 @@ set -euo pipefail
 root="$(cd "$(dirname "$0")/.." && pwd)"
 module=github.com/KirkDiggler/rpg-toolkit/encounter
 case "$1" in
-  on) mkdir -p "$root/local-toolkit/encounter"; printf '\nreplace %s => ./local-toolkit/encounter\n' "$module" >> "$root/go.mod" ;;
+  on)
+    mkdir -p "$root/local-toolkit/encounter"
+    printf '\nreplace %s => ./local-toolkit/encounter\n' "$module" >> "$root/go.mod"
+    [ "${FAKE_OVERRIDE_ON_FAIL:-false}" != true ] || exit 42
+    ;;
   status)
     if grep -q '^replace ' "$root/go.mod"; then echo "Override ON: $module => ./local-toolkit/encounter"
     else echo "Active replace modules (0): none"; echo "Override OFF: $module resolves to its published version."
@@ -29,6 +33,10 @@ cat > "$TMP/bin/docker" <<'MOCK'
 printf '%s\n' "$*" >> "$FAKE_DOCKER_LOG"
 if [ "${1:-} ${2:-}" = "container inspect" ]; then
   [ "${3:-}" = "${FAKE_CONTAINER_EXISTS:-__none__}" ] && exit 0
+  exit 1
+fi
+if [ "${1:-} ${2:-}" = "image inspect" ]; then
+  [ "${3:-}" = "${FAKE_IMAGE_EXISTS:-__none__}" ] && exit 0
   exit 1
 fi
 if [ "${1:-} ${2:-}" = "network inspect" ]; then exit 0; fi
@@ -65,6 +73,42 @@ if FAKE_CONTAINER_EXISTS=rpg-toolkit-lab-collide-api \
 fi
 grep -q "already exists" "$TMP/collision.err"
 ! grep -q '^replace ' "$TMP/api/go.mod"
+
+# A helper that mutates go.mod/local-toolkit and then fails must still be rolled back.
+if FAKE_OVERRIDE_ON_FAIL=true \
+  $SUBJECT up --api "$TMP/api" --toolkit "$TMP/toolkit" --name partialon --envoy-port 48184 >/dev/null 2>"$TMP/partial.err"; then
+  echo "expected partial override activation failure" >&2
+  exit 1
+fi
+grep -q "partial API override state were removed" "$TMP/partial.err"
+! grep -q '^replace ' "$TMP/api/go.mod"
+[ ! -e "$TMP/api/local-toolkit" ]
+[ ! -e "$ROOT/tmp/toolkit-labs/partialon" ]
+
+# A genuinely pre-existing approved override is restored byte-for-byte on failure.
+"$TMP/api/scripts/toolkit-local-override.sh" on
+printf 'preserve-me\n' > "$TMP/api/local-toolkit/encounter/marker"
+cp "$TMP/api/go.mod" "$TMP/preexisting.go.mod"
+if FAKE_OVERRIDE_ON_FAIL=true \
+  $SUBJECT up --api "$TMP/api" --toolkit "$TMP/toolkit" --name preserve --envoy-port 48185 >/dev/null 2>"$TMP/preserve.err"; then
+  echo "expected startup failure with pre-existing override" >&2
+  exit 1
+fi
+cmp "$TMP/preexisting.go.mod" "$TMP/api/go.mod"
+grep -qx 'preserve-me' "$TMP/api/local-toolkit/encounter/marker"
+grep -q "pre-existing API override was restored" "$TMP/preserve.err"
+"$TMP/api/scripts/toolkit-local-override.sh" off
+
+# Cleanup must report a stuck name-scoped resource instead of claiming success.
+if FAKE_CONTAINER_EXISTS=rpg-toolkit-lab-stuck-envoy FAKE_IMAGE_EXISTS=rpg-api:toolkit-lab-stuck \
+  $SUBJECT down --api "$TMP/api" --name stuck >"$TMP/stuck.out" 2>"$TMP/stuck.err"; then
+  echo "expected stuck-resource cleanup failure" >&2
+  exit 1
+fi
+grep -q "failed to remove name-scoped container" "$TMP/stuck.err"
+grep -q "failed to remove name-scoped image" "$TMP/stuck.err"
+grep -q "cleanup is incomplete" "$TMP/stuck.err"
+! grep -q "is down" "$TMP/stuck.out"
 
 python3 -m http.server 48183 --bind 127.0.0.1 >"$TMP/http.log" 2>&1 &
 server_pid=$!

--- a/scripts/test-toolkit-override-lab.sh
+++ b/scripts/test-toolkit-override-lab.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SUBJECT="$ROOT/scripts/toolkit-override-lab.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+mkdir -p "$TMP/bin" "$TMP/api/scripts" "$TMP/toolkit/encounter"
+printf 'module github.com/KirkDiggler/rpg-api\n' > "$TMP/api/go.mod"
+printf 'module github.com/KirkDiggler/rpg-toolkit/encounter\n' > "$TMP/toolkit/encounter/go.mod"
+: > "$TMP/api/Dockerfile.local-toolkit"
+cat > "$TMP/api/scripts/toolkit-local-override.sh" <<'MOCK'
+#!/usr/bin/env bash
+set -euo pipefail
+root="$(cd "$(dirname "$0")/.." && pwd)"
+module=github.com/KirkDiggler/rpg-toolkit/encounter
+case "$1" in
+  on) mkdir -p "$root/local-toolkit/encounter"; printf '\nreplace %s => ./local-toolkit/encounter\n' "$module" >> "$root/go.mod" ;;
+  status)
+    if grep -q '^replace ' "$root/go.mod"; then echo "Override ON: $module => ./local-toolkit/encounter"
+    else echo "Active replace modules (0): none"; echo "Override OFF: $module resolves to its published version."
+    fi ;;
+  off) sed -i '\|^replace github.com/KirkDiggler/rpg-toolkit/encounter => ./local-toolkit/encounter$|d' "$root/go.mod"; rm -rf "$root/local-toolkit" ;;
+  *) exit 2 ;;
+esac
+MOCK
+chmod +x "$TMP/api/scripts/toolkit-local-override.sh"
+cat > "$TMP/bin/docker" <<'MOCK'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$FAKE_DOCKER_LOG"
+if [ "${1:-} ${2:-}" = "container inspect" ]; then
+  [ "${3:-}" = "${FAKE_CONTAINER_EXISTS:-__none__}" ] && exit 0
+  exit 1
+fi
+if [ "${1:-} ${2:-}" = "network inspect" ]; then exit 0; fi
+if [ "${1:-}" = inspect ]; then echo true; exit 0; fi
+if [ "${1:-}" = run ]; then echo fake-id; exit 0; fi
+exit 0
+MOCK
+cat > "$TMP/bin/curl" <<'MOCK'
+#!/usr/bin/env bash
+exit 0
+MOCK
+chmod +x "$TMP/bin/docker" "$TMP/bin/curl"
+export PATH="$TMP/bin:$PATH" FAKE_DOCKER_LOG="$TMP/docker.log"
+
+output="$($SUBJECT up --api "$TMP/api" --toolkit "$TMP/toolkit" --name testsafe --envoy-port 48181 --vite-port 45173)"
+grep -q "API URL: http://localhost:48181" <<<"$output"
+grep -q "VITE_API_HOST=http://localhost:48181 npm run dev -- --port 45173" <<<"$output"
+grep -q "build -f $TMP/api/Dockerfile.local-toolkit -t rpg-api:toolkit-lab-testsafe $TMP/api" "$FAKE_DOCKER_LOG"
+grep -q -- "--name rpg-toolkit-lab-testsafe-api" "$FAKE_DOCKER_LOG"
+grep -q -- "--name rpg-toolkit-lab-testsafe-envoy" "$FAKE_DOCKER_LOG"
+grep -q "address: rpg-toolkit-lab-testsafe-api" "$ROOT/tmp/toolkit-labs/testsafe/envoy.yaml"
+
+$SUBJECT down --api "$TMP/api" --name testsafe >/dev/null
+! grep -q '^replace ' "$TMP/api/go.mod"
+[ ! -e "$TMP/api/local-toolkit" ]
+[ ! -e "$ROOT/tmp/toolkit-labs/testsafe" ]
+# Down is deliberately idempotent.
+$SUBJECT down --api "$TMP/api" --name testsafe >/dev/null
+
+if FAKE_CONTAINER_EXISTS=rpg-toolkit-lab-collide-api \
+  $SUBJECT up --api "$TMP/api" --toolkit "$TMP/toolkit" --name collide --envoy-port 48182 >/dev/null 2>"$TMP/collision.err"; then
+  echo "expected container collision failure" >&2
+  exit 1
+fi
+grep -q "already exists" "$TMP/collision.err"
+! grep -q '^replace ' "$TMP/api/go.mod"
+
+python3 -m http.server 48183 --bind 127.0.0.1 >"$TMP/http.log" 2>&1 &
+server_pid=$!
+trap 'kill "$server_pid" 2>/dev/null || true; rm -rf "$TMP"' EXIT
+sleep 0.2
+! $SUBJECT up --api "$TMP/api" --toolkit "$TMP/toolkit" --name portcheck --envoy-port 48183 >/dev/null 2>"$TMP/port.err"
+grep -q "already in use" "$TMP/port.err"
+! grep -q '^replace ' "$TMP/api/go.mod"
+kill "$server_pid"
+trap 'rm -rf "$TMP"' EXIT
+
+echo "toolkit override lab tests: PASS"

--- a/scripts/toolkit-override-lab.sh
+++ b/scripts/toolkit-override-lab.sh
@@ -49,22 +49,73 @@ IMAGE="rpg-api:toolkit-lab-${LAB_NAME}"
 STATE_DIR="$ROOT/tmp/toolkit-labs/$LAB_NAME"
 
 container_exists() { docker container inspect "$1" >/dev/null 2>&1; }
+image_exists() { docker image inspect "$1" >/dev/null 2>&1; }
 
 verify_clean() {
-  if grep -Eq "^[[:space:]]*replace[[:space:]]+$MODULE[[:space:]]*=>[[:space:]]*\./local-toolkit/encounter" "$API_DIR/go.mod"; then
-    die "override residue remains in $API_DIR/go.mod; run '$OVERRIDE off' and inspect the worktree"
+  local failed=0 clean_status=""
+  if ! clean_status="$("$OVERRIDE" status)"; then
+    echo "error: API override helper status check failed after cleanup" >&2
+    failed=1
+  elif ! grep -Fq "Active replace modules (0): none" <<<"$clean_status"; then
+    echo "error: API override helper still reports an active replace after cleanup" >&2
+    failed=1
   fi
-  [ ! -e "$API_DIR/local-toolkit" ] || die "override residue remains at $API_DIR/local-toolkit"
+  if grep -Eq "^[[:space:]]*replace[[:space:]]+$MODULE[[:space:]]*=>[[:space:]]*\./local-toolkit/encounter" "$API_DIR/go.mod"; then
+    echo "error: override residue remains in $API_DIR/go.mod; run '$OVERRIDE off' and inspect the worktree" >&2
+    failed=1
+  fi
+  if [ -e "$API_DIR/local-toolkit" ]; then
+    echo "error: override residue remains at $API_DIR/local-toolkit" >&2
+    failed=1
+  fi
+  return "$failed"
+}
+
+remove_lab_resources() {
+  local failed=0
+  for container in "$ENVOY_CONTAINER" "$API_CONTAINER"; do
+    for _ in 1 2 3; do
+      container_exists "$container" || break
+      docker rm -f "$container" >/dev/null 2>&1 || true
+      for _ in 1 2 3 4 5; do
+        container_exists "$container" || break 2
+        sleep 0.2
+      done
+    done
+    if container_exists "$container"; then
+      echo "error: failed to remove name-scoped container '$container'" >&2
+      failed=1
+    fi
+  done
+  for _ in 1 2 3; do
+    image_exists "$IMAGE" || break
+    docker image rm "$IMAGE" >/dev/null 2>&1 || true
+    sleep 0.2
+  done
+  if image_exists "$IMAGE"; then
+    echo "error: failed to remove name-scoped image '$IMAGE'" >&2
+    failed=1
+  fi
+  rm -rf "$STATE_DIR"
+  if [ -e "$STATE_DIR" ]; then
+    echo "error: failed to remove generated lab state '$STATE_DIR'" >&2
+    failed=1
+  fi
+  return "$failed"
 }
 
 cleanup() {
-  docker rm -f "$ENVOY_CONTAINER" "$API_CONTAINER" >/dev/null 2>&1 || true
-  docker image rm "$IMAGE" >/dev/null 2>&1 || true
-  rm -rf "$STATE_DIR"
-  "$OVERRIDE" off
-  clean_status="$("$OVERRIDE" status)"
-  grep -Fq "Active replace modules (0): none" <<<"$clean_status" || die "API override helper still reports an active replace after cleanup"
-  verify_clean
+  local failed=0
+  if ! remove_lab_resources; then failed=1; fi
+  if ! "$OVERRIDE" off; then
+    echo "error: API override helper cleanup failed" >&2
+    failed=1
+  fi
+  if ! verify_clean; then failed=1; fi
+  if [ "$failed" -ne 0 ]; then
+    echo "error: lab '$LAB_NAME' cleanup is incomplete; inspect the errors above" >&2
+    return 1
+  fi
   echo "Lab '$LAB_NAME' is down; containers, image, generated Envoy config, and API override residue removed."
 }
 
@@ -108,27 +159,68 @@ if [ -n "$VITE_PORT" ]; then
   validate_port "Vite port" "$VITE_PORT"
 fi
 
+initial_status=""
+if ! initial_status="$("$OVERRIDE" status)"; then
+  die "API override helper status failed before startup; inspect the API worktree"
+fi
+override_preexisting=false
+if grep -Fq "Override ON: $MODULE" <<<"$initial_status"; then
+  override_preexisting=true
+elif ! grep -Fq "Active replace modules (0): none" <<<"$initial_status"; then
+  die "API override state is neither clean nor the approved encounter override"
+fi
+
 mkdir -p "$STATE_DIR"
 sed "s/address: rpg-api  # Docker service name/address: $API_CONTAINER  # isolated toolkit lab/" \
   "$ROOT/envoy/envoy.yaml" > "$STATE_DIR/envoy.yaml"
 grep -q "address: $API_CONTAINER" "$STATE_DIR/envoy.yaml" || die "failed to generate isolated Envoy upstream"
 
-override_on=false
+PREEXISTING_BACKUP="$STATE_DIR/preexisting-api-override"
+if [ "$override_preexisting" = true ]; then
+  mkdir -p "$PREEXISTING_BACKUP"
+  cp -a "$API_DIR/go.mod" "$PREEXISTING_BACKUP/go.mod"
+  if [ -e "$API_DIR/go.sum" ]; then cp -a "$API_DIR/go.sum" "$PREEXISTING_BACKUP/go.sum"; fi
+  [ -e "$API_DIR/local-toolkit" ] || die "approved pre-existing override has no local-toolkit directory to preserve"
+  cp -a "$API_DIR/local-toolkit" "$PREEXISTING_BACKUP/local-toolkit"
+fi
+
 up_failed() {
-  status=$?
+  local status=$? rollback_failed=0 restored_status=""
   if [ "$status" -ne 0 ]; then
-    docker rm -f "$ENVOY_CONTAINER" "$API_CONTAINER" >/dev/null 2>&1 || true
-    docker image rm "$IMAGE" >/dev/null 2>&1 || true
-    rm -rf "$STATE_DIR"
-    if [ "$override_on" = true ]; then "$OVERRIDE" off || true; fi
-    echo "error: lab startup failed; isolated resources were rolled back" >&2
+    if [ "$override_preexisting" = true ]; then
+      cp -a "$PREEXISTING_BACKUP/go.mod" "$API_DIR/go.mod" || rollback_failed=1
+      if [ -e "$PREEXISTING_BACKUP/go.sum" ]; then
+        cp -a "$PREEXISTING_BACKUP/go.sum" "$API_DIR/go.sum" || rollback_failed=1
+      else
+        rm -f "$API_DIR/go.sum" || rollback_failed=1
+      fi
+      rm -rf "$API_DIR/local-toolkit"
+      cp -a "$PREEXISTING_BACKUP/local-toolkit" "$API_DIR/local-toolkit" || rollback_failed=1
+      if ! restored_status="$("$OVERRIDE" status)" || ! grep -Fq "Override ON: $MODULE" <<<"$restored_status"; then
+        echo "error: failed to restore the pre-existing approved API override" >&2
+        rollback_failed=1
+      fi
+    else
+      if ! "$OVERRIDE" off; then
+        echo "error: API helper failed while rolling back a partial override activation" >&2
+        rollback_failed=1
+      fi
+      if ! verify_clean; then rollback_failed=1; fi
+    fi
+    if ! remove_lab_resources; then rollback_failed=1; fi
+    if [ "$rollback_failed" -ne 0 ]; then
+      echo "error: lab startup failed and rollback is incomplete; inspect the errors above" >&2
+    elif [ "$override_preexisting" = true ]; then
+      echo "error: lab startup failed; isolated resources were removed and the pre-existing API override was restored" >&2
+    else
+      echo "error: lab startup failed; isolated resources and partial API override state were removed" >&2
+    fi
   fi
   exit "$status"
 }
 trap up_failed EXIT
 
 "$OVERRIDE" on --src "$TOOLKIT_DIR"
-override_on=true
 status_output="$("$OVERRIDE" status)"
 grep -Fq "Override ON: $MODULE" <<<"$status_output" || die "existing override helper did not activate the approved encounter module"
 

--- a/scripts/toolkit-override-lab.sh
+++ b/scripts/toolkit-override-lab.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# Run an unpublished rpg-toolkit/encounter checkout through an isolated API + Envoy lab.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+MODULE="github.com/KirkDiggler/rpg-toolkit/encounter"
+ACTION="${1:-}"
+[ $# -gt 0 ] && shift || true
+API_DIR=""
+TOOLKIT_DIR=""
+LAB_NAME=""
+ENVOY_PORT=""
+VITE_PORT=""
+NETWORK="rpg-deployment_rpg-network"
+
+usage() {
+  cat >&2 <<'EOF'
+Usage:
+  scripts/toolkit-override-lab.sh up --api <rpg-api-worktree> --toolkit <rpg-toolkit-worktree> \
+      --name <unique-name> --envoy-port <port> [--vite-port <port>] [--network <docker-network>]
+  scripts/toolkit-override-lab.sh down --api <rpg-api-worktree> --name <unique-name>
+EOF
+  exit 2
+}
+
+die() { echo "error: $*" >&2; exit 1; }
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --api) [ $# -ge 2 ] || usage; API_DIR="$2"; shift 2 ;;
+    --toolkit) [ $# -ge 2 ] || usage; TOOLKIT_DIR="$2"; shift 2 ;;
+    --name) [ $# -ge 2 ] || usage; LAB_NAME="$2"; shift 2 ;;
+    --envoy-port) [ $# -ge 2 ] || usage; ENVOY_PORT="$2"; shift 2 ;;
+    --vite-port) [ $# -ge 2 ] || usage; VITE_PORT="$2"; shift 2 ;;
+    --network) [ $# -ge 2 ] || usage; NETWORK="$2"; shift 2 ;;
+    *) usage ;;
+  esac
+done
+
+[ "$ACTION" = up ] || [ "$ACTION" = down ] || usage
+[ -n "$API_DIR" ] && [ -n "$LAB_NAME" ] || usage
+[[ "$LAB_NAME" =~ ^[a-z0-9][a-z0-9-]{0,31}$ ]] || die "lab name must match [a-z0-9][a-z0-9-]{0,31}"
+API_DIR="$(cd "$API_DIR" 2>/dev/null && pwd)" || die "API worktree does not exist: $API_DIR"
+OVERRIDE="$API_DIR/scripts/toolkit-local-override.sh"
+[ -x "$OVERRIDE" ] || die "missing executable override helper: $OVERRIDE"
+API_CONTAINER="rpg-toolkit-lab-${LAB_NAME}-api"
+ENVOY_CONTAINER="rpg-toolkit-lab-${LAB_NAME}-envoy"
+IMAGE="rpg-api:toolkit-lab-${LAB_NAME}"
+STATE_DIR="$ROOT/tmp/toolkit-labs/$LAB_NAME"
+
+container_exists() { docker container inspect "$1" >/dev/null 2>&1; }
+
+verify_clean() {
+  if grep -Eq "^[[:space:]]*replace[[:space:]]+$MODULE[[:space:]]*=>[[:space:]]*\./local-toolkit/encounter" "$API_DIR/go.mod"; then
+    die "override residue remains in $API_DIR/go.mod; run '$OVERRIDE off' and inspect the worktree"
+  fi
+  [ ! -e "$API_DIR/local-toolkit" ] || die "override residue remains at $API_DIR/local-toolkit"
+}
+
+cleanup() {
+  docker rm -f "$ENVOY_CONTAINER" "$API_CONTAINER" >/dev/null 2>&1 || true
+  docker image rm "$IMAGE" >/dev/null 2>&1 || true
+  rm -rf "$STATE_DIR"
+  "$OVERRIDE" off
+  clean_status="$("$OVERRIDE" status)"
+  grep -Fq "Active replace modules (0): none" <<<"$clean_status" || die "API override helper still reports an active replace after cleanup"
+  verify_clean
+  echo "Lab '$LAB_NAME' is down; containers, image, generated Envoy config, and API override residue removed."
+}
+
+if [ "$ACTION" = down ]; then
+  cleanup
+  exit 0
+fi
+
+[ -n "$TOOLKIT_DIR" ] && [ -n "$ENVOY_PORT" ] || usage
+TOOLKIT_DIR="$(cd "$TOOLKIT_DIR" 2>/dev/null && pwd)" || die "toolkit worktree does not exist: $TOOLKIT_DIR"
+[ -f "$TOOLKIT_DIR/encounter/go.mod" ] || die "toolkit checkout lacks encounter/go.mod: $TOOLKIT_DIR"
+[ -f "$API_DIR/Dockerfile.local-toolkit" ] || die "API worktree lacks Dockerfile.local-toolkit"
+
+docker network inspect "$NETWORK" >/dev/null 2>&1 || die "Docker network '$NETWORK' does not exist; start the local dependency stack first"
+for container in "$API_CONTAINER" "$ENVOY_CONTAINER"; do
+  container_exists "$container" && die "container '$container' already exists; choose another --name or run this lab's down command"
+done
+
+validate_port() {
+  local label="$1" port="$2"
+  [[ "$port" =~ ^[0-9]+$ ]] && [ "$port" -ge 1024 ] && [ "$port" -le 65535 ] || die "$label must be an integer from 1024 to 65535"
+  python3 - "$port" <<'PY' || die "$label $port is already in use; choose another port"
+import socket, sys
+port = int(sys.argv[1])
+sockets = []
+for family, address in ((socket.AF_INET, "0.0.0.0"), (socket.AF_INET6, "::")):
+    try:
+        sock = socket.socket(family, socket.SOCK_STREAM)
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 0)
+        if family == socket.AF_INET6:
+            sock.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, 1)
+        sock.bind((address, port))
+        sockets.append(sock)
+    except OSError:
+        sys.exit(1)
+PY
+}
+validate_port "Envoy port" "$ENVOY_PORT"
+if [ -n "$VITE_PORT" ]; then
+  [ "$VITE_PORT" != "$ENVOY_PORT" ] || die "Vite port must differ from Envoy port"
+  validate_port "Vite port" "$VITE_PORT"
+fi
+
+mkdir -p "$STATE_DIR"
+sed "s/address: rpg-api  # Docker service name/address: $API_CONTAINER  # isolated toolkit lab/" \
+  "$ROOT/envoy/envoy.yaml" > "$STATE_DIR/envoy.yaml"
+grep -q "address: $API_CONTAINER" "$STATE_DIR/envoy.yaml" || die "failed to generate isolated Envoy upstream"
+
+override_on=false
+up_failed() {
+  status=$?
+  if [ "$status" -ne 0 ]; then
+    docker rm -f "$ENVOY_CONTAINER" "$API_CONTAINER" >/dev/null 2>&1 || true
+    docker image rm "$IMAGE" >/dev/null 2>&1 || true
+    rm -rf "$STATE_DIR"
+    if [ "$override_on" = true ]; then "$OVERRIDE" off || true; fi
+    echo "error: lab startup failed; isolated resources were rolled back" >&2
+  fi
+  exit "$status"
+}
+trap up_failed EXIT
+
+"$OVERRIDE" on --src "$TOOLKIT_DIR"
+override_on=true
+status_output="$("$OVERRIDE" status)"
+grep -Fq "Override ON: $MODULE" <<<"$status_output" || die "existing override helper did not activate the approved encounter module"
+
+docker build -f "$API_DIR/Dockerfile.local-toolkit" -t "$IMAGE" "$API_DIR"
+docker run -d --name "$API_CONTAINER" --network "$NETWORK" \
+  --label "rpg.toolkit-lab=$LAB_NAME" \
+  -e PORT=50051 -e LOG_LEVEL=info -e REDIS_ADDR=redis:6379 -e AUTH_DEV_MODE=true \
+  -e DND5E_API_URL=http://dnd-api:3000/api/2014/ "$IMAGE" >/dev/null
+docker run -d --name "$ENVOY_CONTAINER" --network "$NETWORK" \
+  --label "rpg.toolkit-lab=$LAB_NAME" -p "$ENVOY_PORT:8080" \
+  -v "$STATE_DIR/envoy.yaml:/etc/envoy/envoy.yaml:ro" envoyproxy/envoy:v1.31-latest \
+  /usr/local/bin/envoy -c /etc/envoy/envoy.yaml -l info >/dev/null
+
+for _ in $(seq 1 30); do
+  [ "$(docker inspect -f '{{.State.Running}}' "$API_CONTAINER")" = true ] || die "API container exited; inspect with: docker logs $API_CONTAINER"
+  [ "$(docker inspect -f '{{.State.Running}}' "$ENVOY_CONTAINER")" = true ] || die "Envoy container exited; inspect with: docker logs $ENVOY_CONTAINER"
+  if curl -sS -o /dev/null "http://localhost:$ENVOY_PORT/"; then break; fi
+  sleep 1
+done
+curl -sS -o /dev/null "http://localhost:$ENVOY_PORT/" || die "Envoy did not become reachable on port $ENVOY_PORT"
+
+trap - EXIT
+cat <<EOF
+Lab '$LAB_NAME' is ready.
+API URL: http://localhost:$ENVOY_PORT
+Vite command:
+  VITE_API_HOST=http://localhost:$ENVOY_PORT npm run dev${VITE_PORT:+ -- --port $VITE_PORT}
+Cleanup:
+  $ROOT/scripts/toolkit-override-lab.sh down --api $API_DIR --name $LAB_NAME
+
+Re-run 'up' after toolkit edits (run 'down' first). This lab shares the existing local Redis/D&D dependencies but does not recreate primary, lab1, or lab2.
+EOF


### PR DESCRIPTION
Closes #65

## Summary

- add `scripts/toolkit-override-lab.sh up|down` for a uniquely named API + Envoy lab around the existing API-owned `encounter` override helper
- validate worktrees, Docker network, container names, Envoy/Vite ports, and the approved active module before starting
- build the API automatically with `Dockerfile.local-toolkit`, generate an isolated Envoy upstream, and print the API URL, exact Vite command, and cleanup command
- make cleanup name-scoped and idempotent, including image/config removal plus verification that the API helper reports zero replaces and no `local-toolkit/` residue exists
- reconcile `LOCAL_DEV.md`, `LOCAL_DEV_WORKFLOW.md`, and the fixed-lab Compose guidance: primary is the stable shared baseline; owned fixed labs or this wrapper are the experiment paths
- add a no-live-container regression suite behind `make test`

The wrapper intentionally shares the already-running Redis and D&D API dependencies. It never invokes Compose, so it cannot recreate primary, lab1, or lab2. Tests that create Redis fixtures still own those fixture keys.

## Verification

- `make test` — PASS: happy path, generated Envoy upstream, exact Vite output, container collision, occupied port, cleanup, and repeated cleanup
- `bash -n scripts/toolkit-override-lab.sh scripts/test-toolkit-override-lab.sh` — PASS
- `docker compose -f docker-compose.local-dev.yml -f docker-compose.local-lab.yml config --quiet` — PASS
- `git diff --check origin/main...HEAD` — PASS

### Live isolated path

Used detached verification worktrees from current `origin/dev` (API) and `origin/main` (toolkit), leaving the primary checkouts untouched:

- real occupied `:8081` was rejected before the API worktree changed
- `up --name issue65verify --envoy-port 8188 --vite-port 5188` invoked the API helper, host-built the override, Docker-built with `Dockerfile.local-toolkit`, and started only:
  - `rpg-toolkit-lab-issue65verify-api`
  - `rpg-toolkit-lab-issue65verify-envoy`
- `curl http://localhost:8188/` reached the real upstream path and returned Envoy's expected gRPC `415` (`grpc-status: 3`) for a content-type-less request
- `down` succeeded twice; the detached API worktree was clean and no labeled lab container remained
- before/after IDs for the existing services were unchanged: `rpg-api` `ea4fe68b9f35`, `rpg-envoy` `c675b9388ba5`, `rpg-api-lab` `247688b7ab8a`, `rpg-api-lab2` `01377b6779d3`

## Done gate

- **Goal:** yes — there is now one documented reversible command for an unpublished toolkit override through isolated API + Envoy containers.
- **Pattern:** yes — it delegates override mechanics to `rpg-api/scripts/toolkit-local-override.sh` and reuses the canonical Envoy config rather than creating another module mechanism or routing policy.
- **Test:** yes — both deterministic mocked regression coverage and the real Docker/API/Envoy path passed alongside existing services.
- **Pushback:** no product or application behavior was added; Redis fixture ownership remains with the test that creates the data.

Not merging; awaiting human review.

— platform agent, on behalf of KirkDiggler