### PR TITLE
feat: enable Dungeon Builder authoring in deployed api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,4 +48,5 @@ node_modules/
 .terraform/
 
 # CloudFormation outputs
-cloudformation-outputs.json
+cloudformation-outputs.jsoncontent/*
+!content/README.md

--- a/content/README.md
+++ b/content/README.md
@@ -1,0 +1,2 @@
+# Authored dungeon YAMLs land here (PutDungeon write-through).
+# Gitignored except this file — content is runtime state, not repo state.

--- a/docker-compose.api.yml
+++ b/docker-compose.api.yml
@@ -13,6 +13,17 @@ services:
       - LOG_LEVEL=info
       - REDIS_URL=redis://redis:6379
       - DND5E_API_URL=http://dnd-api:3000/api/
+      # Dungeon Builder authoring surface (rpg-project#169 design: "remote
+      # phase = flip env gate in deployed compose"). The gate REQUIRES
+      # RPG_CONTENT_DIR at construction; PutDungeon writes through to files
+      # in that dir, so it must be a persistent volume, not container-local.
+      - RPG_AUTHORING_ENABLED=1
+      - RPG_CONTENT_DIR=/content
+    volumes:
+      # Authored dungeon YAMLs (write-through persistence for PutDungeon).
+      # Empty dir is valid — embedded dungeons (reference-tomb, fog-lab)
+      # always exist; authored ones accumulate here across restarts.
+      - ./content:/content
     depends_on:
       - redis
       - dnd-api


### PR DESCRIPTION
Flips the long-planned env gate: `RPG_AUTHORING_ENABLED=1` + `RPG_CONTENT_DIR=/content` with a persistent `./content` volume on the deployed api. Empty content dir is valid (embedded dungeons always exist); authored dungeons persist across restarts.

The web client needs no change: its Home button probes this server at runtime — Unimplemented hides the button, live shows it (rpg-dnd5e-web#719).

Deploy after the two release cuts (rpg-dnd5e-web#730, rpg-api#778) merge and GHCR `:latest` images republish: `docker compose pull && docker compose up -d` per the normal flow.

— asset-pipeline agent, on behalf of KirkDiggler

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FjjqMaDZH7NwpzczZ29fU4