### PR TITLE
fix: authoring env on docker-compose.prod.yml (the file production deploys)

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -37,6 +37,20 @@ services:
       # only ever be live alongside a compatible image). Instant rollback:
       # remove this line and redeploy.
       - RPG_DUNGEON_KEY=reference-tomb
+      # Dungeon Builder authoring surface (rpg-project#169: "remote phase =
+      # flip env gate in deployed compose"). NOTE: PR #67 put these on
+      # docker-compose.api.yml, which the production pipeline never reads --
+      # deploy.yml runs docker-compose.prod.yml, this file. The gate REQUIRES
+      # RPG_CONTENT_DIR at construction; PutDungeon writes through to files
+      # there, so it must be a bind mount that survives the pipeline's
+      # down/up cycle (untracked paths survive its `git reset --hard`).
+      # Instant rollback: remove these two lines + the volume and redeploy.
+      - RPG_AUTHORING_ENABLED=1
+      - RPG_CONTENT_DIR=/content
+    volumes:
+      # Authored dungeon YAMLs (write-through persistence). Empty dir is
+      # valid -- embedded dungeons always exist; authored ones accumulate.
+      - ./content:/content
     depends_on:
       - redis
     networks:


### PR DESCRIPTION
#67 was a production no-op: it patched `docker-compose.api.yml`, but `deploy.yml`'s SSM step runs `docker-compose.prod.yml`, which defines its own self-contained `rpg-api` service. This puts the same two env vars + the persistent `./content` bind mount on the file the pipeline actually deploys.

On merge, the deploy workflow rolls it out automatically — no manual box access. The deployed client then shows the Dungeon Builder button on its own (runtime probe, rpg-dnd5e-web#719).

If the button still hides after this lands, the next suspect is auth-scheme handling on the authoring probe under Discord auth (vs the local Dev scheme) — flag it and we'll chase that server-side.

— asset-pipeline agent, on behalf of KirkDiggler

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FjjqMaDZH7NwpzczZ29fU4